### PR TITLE
add label node and improve output tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ Lilac parser
 
 > A toy combinator parser with better failure reasons.
 
-Demo of `(def a (add 1 2))` or `{"json": [1, 2]` http://repo.mvc-works.org/lilac-parser/
+Demo of `(def a (add 1 2))` or `{"json": [1, 2]}` http://repo.mvc-works.org/lilac-parser/
 
 ### Usage
 
 [![Clojars Project](https://img.shields.io/clojars/v/mvc-works/lilac-parser.svg)](https://clojars.org/mvc-works/lilac-parser)
 
 ```edn
-[mvc-works/lilac-parser "0.0.2-a2"]
+[mvc-works/lilac-parser "0.0.2-a3"]
 ```
 
 ```clojure
 (require '[lilac-parser.core :refer
-            [parse-lilac defparser is+ many+ one-of+ some+ combine+ interleave+ other-than+]])
+            [parse-lilac defparser is+ many+ one-of+ some+ combine+ interleave+ other-than+ label+]])
 
 (parse-lilac "aaaa" (many+ (is+ "a")))
 ```

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -106,6 +106,135 @@
               :id |RIEppgu6
           :id |j0_nfxFtz
         :defs $ {}
+          |parse-label $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867346187)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867346187) (:text |defn) (:id |RYxwiFMjTZ)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867346187) (:text |parse-label) (:id |j248bJk0eK)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867346187)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867363188) (:text |xs) (:id |gryL1x3EuZ)
+                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867363936) (:text |rule) (:id |SOBGfvwial)
+                :id |wxzn2nTWo4
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867426796)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867427301) (:text |let) (:id |M2AOejHVtJleaf)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867427928)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867428100)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867432352) (:text |result) (:id |A0CpsS83a)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867433140)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867433140) (:text |parse-lilac) (:id |UCa3N5E4mw)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867433140) (:text |xs) (:id |49kZNv6nO5)
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867437086)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867510458) (:text |:item) (:id |hXw7qOfF1)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867438801) (:text |rule) (:id |EKeeGqQ_UW)
+                                :id |TMQILHZW6
+                            :id |n5wma9csx3
+                        :id |zlDNnC7uP
+                    :id |9mxdHKL7p6
+                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867444729)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867445135) (:text |if) (:id |6hK4WwyuWleaf)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867446203)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867449031) (:text |:ok?) (:id |tVm7U6-sUE)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867451032) (:text |result) (:id |C2D3aCQZs)
+                        :id |Z2s9Q-K_l
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867451829)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867452473) (:text |{}) (:id |vixhNQNNeHleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867455800)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867456736) (:text |:ok?) (:id |AqELJILhc)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867457349) (:text |true) (:id |IWUi7V_ip6)
+                            :id |Pv4olUcRaA
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867458206)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867459087) (:text |:value) (:id |ORHocxKOEleaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867460557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867461954) (:text |:value) (:id |sjlThOBvWg)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867463592) (:text |result) (:id |MOHRN9z6Wm)
+                                :id |45BxxCmOp
+                            :id |ORHocxKOE
+                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867464356)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867466367) (:text |:rest) (:id |Yz9cy5XCTnleaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867466872)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867546778) (:text |:rest) (:id |hZfxArCjwA)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867469476) (:text |result) (:id |QG4_qu7HnY)
+                                :id |hLeSk9tHrN
+                            :id |Yz9cy5XCTn
+                          |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867476182)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867478832) (:text |:parser-node) (:id |IzcdqmK1qleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868199167) (:text |:label) (:id |QuF26IIwTn)
+                            :id |IzcdqmK1q
+                          |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868117144)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868117144) (:text |:result) (:id |3G11TDrf50)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868117144) (:text |result) (:id |WHx78EsPjK)
+                            :id |mXKE25NrcT
+                          |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868188741)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868191393) (:text |:label) (:id |IzcdqmK1qleaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868196836)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868196836) (:text |:label) (:id |Xo51O2bFmZ)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868196836) (:text |rule) (:id |07vRsg8Sq3)
+                                :id |6BuR2Y_Hxd
+                            :id |9rVMAEA34
+                            :text |:la
+                        :id |vixhNQNNeH
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867511855)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867512347) (:text |{}) (:id |HoX459cY9qleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867512992)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867516821) (:text |:ok?) (:id |0JRsFDmd7A)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867515637) (:text |false) (:id |Hi4akNzR6)
+                            :id |ms72fOIFiH
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867527419)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867527419) (:text |:parser-node) (:id |2AwItXwkXI)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867780457) (:text |:label) (:id |-xQhbJ7rf1)
+                            :id |L2Go7eE98B
+                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867528253)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867529940) (:text |:result) (:id |Is-BdYdXzleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867537720) (:text |result) (:id |hsBbhuSXUS)
+                            :id |Is-BdYdXz
+                          |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867538517)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867539410) (:text |:rest) (:id |MZtj700bL1leaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867540269)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867542268) (:text |:rest) (:id |_KNiN-_ss)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867544706) (:text |result) (:id |F3uap8KFUx)
+                                :id |LB9TKb9_Pg
+                            :id |MZtj700bL1
+                          |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867699596)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867701272) (:text |:message) (:id |a-kAhfS_Dleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869289388) (:text |nil) (:id |IPFENRVsTm)
+                            :id |a-kAhfS_D
+                          |t $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867527419)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868209505) (:text |:label) (:id |2AwItXwkXI)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867780457)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867780457) (:text |:label) (:id |-xQhbJ7rf1)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867780457) (:text |rule) (:id |AHyRbf2AGP)
+                                :id |kFGuBk5M21
+                            :id |P9bfxLBGxx
+                        :id |HoX459cY9q
+                    :id |6hK4WwyuW
+                :id |M2AOejHVtJ
+            :id |OeVyJ-wN2q
           |many+ $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584121099445)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584121099445) (:text |defn) (:id |-CrNU2sVJP)
@@ -295,7 +424,7 @@
                                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588589065081)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588589065081) (:text |:message) (:id |1LNf0TJMENd)
-                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588589220298) (:text "|\"no match in interleave") (:id |ICmO0BwQ3lD)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869845968) (:text "|\"no match") (:id |ICmO0BwQ3lD)
                                         :id |_6OVIkbBplN
                                       |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588589065081)
                                         :data $ {}
@@ -665,7 +794,7 @@
                                       |l $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584205672228)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205672228) (:text |:message) (:id |qwRFGM6Dk)
-                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205672228) (:text "|\"no match in many") (:id |X4nk_0w8P)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869433488) (:text "|\"no match") (:id |X4nk_0w8P)
                                         :id |YADMzXlqv
                                       |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584256004316)
                                         :data $ {}
@@ -911,8 +1040,13 @@
                           |qT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584205957164)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205957164) (:text |:parser-node) (:id |3C7YUpkkf)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205957164) (:text |rule-name) (:id |qdJaJuEd1)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869713484) (:text |:component) (:id |qdJaJuEd1)
                             :id |TGkwVcA-Y
+                          |qj $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869705819)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869708239) (:text |:label) (:id |CPIrhqVJH1leaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869708820) (:text |rule-name) (:id |3Tn1OA_jC9)
+                            :id |CPIrhqVJH1
                         :id |qRTwUu5H
                       |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584192978911)
                         :data $ {}
@@ -925,7 +1059,7 @@
                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584192981884)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205965983) (:text |:parser-node) (:id |oLEK1_V8I)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584192981884) (:text |rule-name) (:id |ao4nWYFoe)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869724317) (:text |:component) (:id |ao4nWYFoe)
                             :id |vuaqiAoS4
                           |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584193027597)
                             :data $ {}
@@ -941,13 +1075,18 @@
                           |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584205962578)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205962578) (:text |:message) (:id |nkJMpM1Gy)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205962578) (:text "|\"failed to parse component") (:id |KJ7q7R4FX)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869251179) (:text "|\"failed branch") (:id |KJ7q7R4FX)
                             :id |QrTnRTQbh
                           |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584256038688)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584256038688) (:text |:rest) (:id |q05NZuXWm)
                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584256038688) (:text |xs) (:id |6DrDliX3w)
                             :id |Y2gH2DH4m
+                          |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869715520)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869717700) (:text |:label) (:id |IsDLJK5exDleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869720818) (:text |rule-name) (:id |zHSzgqAUkT)
+                            :id |IsDLJK5exD
                         :id |wDaZ0u-de
                     :id |UmtCHpicl
                 :id |O0C_V7iN
@@ -1305,7 +1444,28 @@
                                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610031999) (:text |pr-str) (:id |_aVLSofmK8)
                                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610033436) (:text |x0) (:id |HMSKXEdRr)
                                         :id |SM8-HUW6J
-                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610052016) (:text "|\"is in not expected item in other-than+") (:id |T9UroN1YfB)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868857342) (:text "|\" among ") (:id |T9UroN1YfB)
+                                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868848963)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868831292)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868832898) (:text |if) (:id |ds7nCokHo)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868833967)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868834985) (:text |string?) (:id |IayR0u8vG)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868836425) (:text |items) (:id |Y95mRe3RH)
+                                                :id |1yBsv_Empv
+                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868840278) (:text |items) (:id |Au3l0i4k6n)
+                                              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868840867)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868844116) (:text |string/join) (:id |aPYgkRSaLf)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868845134) (:text "|\"") (:id |IwdK6p95B5)
+                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868845923) (:text |items) (:id |f8-71uCKiU)
+                                                :id |YOYbReFxvn
+                                            :id |usjK654Ik
+                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868852293) (:text |pr-str) (:id |8bNI7Pulc)
+                                        :id |8ZI1VDiIxy
+                                      |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868860976) (:text "|\" is invalid") (:id |SrNsQeILz4)
                                     :id |qlIgEANcvO
                                 :id |ehIoDy2ljQ
                               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610016289)
@@ -1659,6 +1819,16 @@
                           |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584197741879) (:text |rule) (:id |b88nml56N)
                         :id |iKQdyx71
                     :id |JQ5p0gOMK
+                  |yij $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867616642)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867618214) (:text |:label) (:id |3ohF4zlax1leaf)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867618963)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867622222) (:text |parse-label) (:id |KoOM2foft_)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867622776) (:text |xs) (:id |P98u6llWEn)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867624086) (:text |rule) (:id |OQooxeIXm5)
+                        :id |6VNXRHR68h
+                    :id |3ohF4zlax1
                 :id |V5RU3g2W
             :id |h8yAAKO7q
           |interleave+ $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588588800820)
@@ -1828,6 +1998,35 @@
                     :id |vdevDlCVfP
                 :id |vGsi2LRLC
             :id |rdF2uQbbuz
+          |label+ $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867316121)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867316121) (:text |defn) (:id |CHJa_k7hiz)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867316121) (:text |label+) (:id |1oyegNLuBE)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867316121)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867324402) (:text |label) (:id |Fe_tGXPkiz)
+                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867327299) (:text |item) (:id |y2GdugC27)
+                :id |Txrs6POFux
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867327852)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867328383) (:text |{}) (:id |BORKVV4ViZleaf)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867328645)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867330533) (:text |:parser-node) (:id |7bycRcvPa3)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867332155) (:text |:label) (:id |ZJ-2fxU_87)
+                    :id |trFXksjVp8
+                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867333262)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867334977) (:text |:item) (:id |jiiy56_dzleaf)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867335463) (:text |item) (:id |ZmXRx6r-4)
+                    :id |jiiy56_dz
+                  |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867729055)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867730215) (:text |:label) (:id |sQPwbulNETleaf)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867731526) (:text |label) (:id |hOu-QqKyqF)
+                    :id |sQPwbulNET
+                :id |BORKVV4ViZ
+            :id |QSnNsPTgzj
           |parse-is $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584185114741)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584185114741) (:text |defn) (:id |S2wFVLlhz)
@@ -1897,16 +2096,32 @@
                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584205419243)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205419672) (:text |str) (:id |WR9i9xyyo)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205444723) (:text "|\"failed to match ") (:id |0bKzuNUw7)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205432673) (:text |item) (:id |c8AC1RMH)
-                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205447405) (:text "|\" in ") (:id |fwnAsdP_)
-                                  |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584205448733)
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868463248)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205454554) (:text |take) (:id |35TmBNxNf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205454862) (:text |10) (:id |TnMp7285n)
-                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205458629) (:text |xs) (:id |TQUzshlk)
-                                    :id |d6PpQj1X
-                                  |y $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205461289) (:text "|\"....") (:id |w1pxlAZp)
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205432673) (:text |item) (:id |c8AC1RMH)
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868464740) (:text |pr-str) (:id |tx7zErMGKt)
+                                    :id |sMwFaIZCW
+                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868575333) (:text "|\" but got ") (:id |fwnAsdP_)
+                                  |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868500789)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868492435)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584205448733)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205454554) (:text |take) (:id |35TmBNxNf)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868474353)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868475095) (:text |count) (:id |TnMp7285n)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868477768) (:text |item) (:id |BS2ojZMocH)
+                                                :id |b5PgRx-6Z6
+                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205458629) (:text |xs) (:id |TQUzshlk)
+                                            :id |d6PpQj1X
+                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868495539) (:text |string/join) (:id |cb2L1tCTA6)
+                                          |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868495915) (:text "|\"") (:id |7sQH4RwFs0)
+                                        :id |jhAS99i3-
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868502235) (:text |pr-str) (:id |TiOFaMKMv)
+                                    :id |MiOhscy5aq
+                                  |f $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868579150) (:text "|\"expects ") (:id |XF_uHIlgZu)
                                 :id |RCanbGF7
                             :id |fDWEJZck
                           |g $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584255970900)
@@ -2305,7 +2520,17 @@
                               |l $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584205658033)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205658033) (:text |:message) (:id |an9oyAz5v)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205658033) (:text "|\"No more rules to try") (:id |XoBI4o3XS)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868600403)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868601788) (:text |str) (:id |XoBI4o3XS)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868606090) (:text "|\"all ") (:id |WXf8VTQSxW)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868606912)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868609131) (:text |count) (:id |1yR3r2Q7UK)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868609687) (:text |items) (:id |73lDveOEau)
+                                        :id |LedxoV-L5V
+                                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868619252) (:text "|\" rules missed") (:id |PzvkqkHBo)
+                                    :id |oe--voNmi0
                                 :id |-PyA4437p
                               |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584255982759)
                                 :data $ {}
@@ -2412,7 +2637,7 @@
                                   |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584204793599)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584204795009) (:text |:message) (:id |Ue-phWaLleaf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584204802615) (:text "|\"unexpected end of file") (:id |PqG5lPyl)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868797107) (:text "|\"unexpected EOF") (:id |PqG5lPyl)
                                     :id |Ue-phWaL
                                   |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584206047325)
                                     :data $ {}
@@ -2494,7 +2719,7 @@
                                           |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584206003774)
                                             :data $ {}
                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584206008288) (:text |:message) (:id |fBCBngd7tleaf)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584206016853) (:text "|\"not matched during combine") (:id |hjVe-3tQY)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869401214) (:text "|\"failed to combine") (:id |hjVe-3tQY)
                                             :id |fBCBngd7t
                                           |l $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584206030763)
                                             :data $ {}
@@ -2721,7 +2946,40 @@
                           |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584199602917)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584199606235) (:text |:message) (:id |Gt8V1oDggleaf)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584199614023) (:text "|\"not in list") (:id |nG-E2e5_A)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868712927)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868714549) (:text |str) (:id |nG-E2e5_A)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868714954)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868716133) (:text |pr-str) (:id |E6l5ZTsshO)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868716690)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868717396) (:text |first) (:id |-SaFBrdTvJ)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868717836) (:text |xs) (:id |a-0S_XkQ2U)
+                                        :id |QNL4aYIDIR
+                                    :id |2A8EyKNph-
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868724075) (:text "|\" is not in ") (:id |6T3krIm58j)
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868747345)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868732328)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868734262)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868726041) (:text |items) (:id |JBQQ7sQYHW)
+                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868736207) (:text |string?) (:id |wqPu9Yw9nT)
+                                            :id |ondSD6zRtU
+                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868732970) (:text |if) (:id |4Iy4zj7nuD)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868739056) (:text |items) (:id |3o0iLuFD3)
+                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868740305)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868743341) (:text |string/join) (:id |ILA6KEk6lleaf)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868744021) (:text "|\"") (:id |z0J2b8PICa)
+                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868745722) (:text |items) (:id |rhW3P4RUS)
+                                            :id |ILA6KEk6l
+                                        :id |9KAcGIWqO
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868748455) (:text |pr-str) (:id |sRUXvXFB2h)
+                                    :id |8saYl-XAk4
+                                :id |x51eYOrvau
                             :id |Gt8V1oDgg
                           |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584206065019)
                             :data $ {}
@@ -3527,6 +3785,7 @@
                         |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588589327548) (:text |is+) (:id |2AQ-pAv03)
                         |yj $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610712000) (:text |optional+) (:id |ECpNAS29lv)
                         |yx $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611142407) (:text |or+) (:id |lqzv5PSpCo)
+                        |yyT $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867668235) (:text |label+) (:id |o4UcoZCcB)
                         |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588589321793) (:text |interleave+) (:id |ouDR6gQcu)
                         |y $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610218607) (:text |many+) (:id |N2lGQrKbzn)
                         |yy $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611309116) (:text |defparser) (:id |i9T1hLmJ2I)
@@ -3580,30 +3839,35 @@
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611386924) (:text |def) (:id |RWkG5zsJr2)
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611386924) (:text |comma-parser) (:id |FWL6TaVRZX)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611386924)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869659370)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611390510) (:text |combine+) (:id |LYIAqjIYjy)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611390936)
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611386924)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611391218) (:text |[]) (:id |hww7E22Xp_)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611396566)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611390510) (:text |combine+) (:id |LYIAqjIYjy)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611390936)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611393765) (:text |is+) (:id |WydF7EQmM7)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611397634) (:text "|\",") (:id |75_jpW7In)
-                        :id |JSSpIJ07U
-                      |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588612371732) (:text |space-parser) (:id |vYeIVzQY4F)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588612376162) (:text |space-parser) (:id |tpM7u5tavM)
-                    :id |j7yMCVkk7Z
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680783603)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680783988) (:text |fn) (:id |tCn0V3sPtVleaf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680784310)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611391218) (:text |[]) (:id |hww7E22Xp_)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611396566)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611393765) (:text |is+) (:id |WydF7EQmM7)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611397634) (:text "|\",") (:id |75_jpW7In)
+                            :id |JSSpIJ07U
+                          |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588612371732) (:text |space-parser) (:id |vYeIVzQY4F)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588612376162) (:text |space-parser) (:id |tpM7u5tavM)
+                        :id |j7yMCVkk7Z
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680783603)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680784702) (:text |x) (:id |xIBjQAlVq)
-                        :id |IrQO5rixdm
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680785768) (:text |nil) (:id |nFSvUoOQB)
-                    :id |tCn0V3sPtV
-                :id |BBqXAFK9Su
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680783988) (:text |fn) (:id |tCn0V3sPtVleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680784310)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680784702) (:text |x) (:id |xIBjQAlVq)
+                            :id |IrQO5rixdm
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680785768) (:text |nil) (:id |nFSvUoOQB)
+                        :id |tCn0V3sPtV
+                    :id |BBqXAFK9Su
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869661704) (:text |label+) (:id |ZLTWczUKTI)
+                  |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869663992) (:text "|\"comma") (:id |sTwm3EQrv)
+                :id |lhOrB3A3VE
             :id |kTWQ-KYxYn
           |value-parser+ $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611414518)
             :data $ {}
@@ -3636,75 +3900,80 @@
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611064298) (:text |def) (:id |wpCkLnLmk_)
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588589998389) (:text |string-parser) (:id |lK4RI_5d6b)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588589998389)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869113009)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611068418) (:text |combine+) (:id |IehrQKl7P)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611068797)
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588589998389)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611069053) (:text |[]) (:id |fDZNedqCjE)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611070809)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611068418) (:text |combine+) (:id |IehrQKl7P)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611068797)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611071347) (:text |is+) (:id |HmoaIF9xa)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611072389) (:text "|\"\"") (:id |jvk3UbosJW)
-                        :id |spjFqZw_x
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611070809)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611071347) (:text |is+) (:id |HmoaIF9xa)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611072389) (:text "|\"\"") (:id |jvk3UbosJW)
-                        :id |1lTpEgV51
-                      |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611076375)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611083500) (:text |some+) (:id |LQsVtghhrC)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611133136)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611069053) (:text |[]) (:id |fDZNedqCjE)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611070809)
                             :data $ {}
-                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611085218)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611071347) (:text |is+) (:id |HmoaIF9xa)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611072389) (:text "|\"\"") (:id |jvk3UbosJW)
+                            :id |spjFqZw_x
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611070809)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611071347) (:text |is+) (:id |HmoaIF9xa)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611072389) (:text "|\"\"") (:id |jvk3UbosJW)
+                            :id |1lTpEgV51
+                          |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611076375)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611083500) (:text |some+) (:id |LQsVtghhrC)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611133136)
                                 :data $ {}
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611088952)
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611085218)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611090621) (:text |other-than+) (:id |xOoGKzIBA)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611096512) (:text "|\"\"\\") (:id |dYTZKKYKL)
-                                    :id |Cm_1gQFWKJ
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611101358)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611103307) (:text |is+) (:id |9Ha9HtU0Fleaf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611107344) (:text "|\"\\\"") (:id |0NV6zs9WeM)
-                                    :id |9Ha9HtU0F
-                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611101358)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611103307) (:text |is+) (:id |9Ha9HtU0Fleaf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611111275) (:text "|\"\\\\") (:id |0NV6zs9WeM)
-                                    :id |RQxFTpR9Rk
-                                  |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611101358)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611103307) (:text |is+) (:id |9Ha9HtU0Fleaf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611114851) (:text "|\"\\n") (:id |0NV6zs9WeM)
-                                    :id |Yem2E-X67
-                                  |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611131501) (:text |[]) (:id |bqGv6M7CLXleaf)
-                                :id |_eSvJFWRe
-                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611133849) (:text |or+) (:id |VDCY4nZsKE)
-                            :id |Kvck6slyo
-                        :id |LNO70h2jO
-                    :id |WET625bddW
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588681050873)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681051174) (:text |fn) (:id |eiXXVeZ9_Bleaf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588681051509)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611088952)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611090621) (:text |other-than+) (:id |xOoGKzIBA)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611096512) (:text "|\"\"\\") (:id |dYTZKKYKL)
+                                        :id |Cm_1gQFWKJ
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611101358)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611103307) (:text |is+) (:id |9Ha9HtU0Fleaf)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611107344) (:text "|\"\\\"") (:id |0NV6zs9WeM)
+                                        :id |9Ha9HtU0F
+                                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611101358)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611103307) (:text |is+) (:id |9Ha9HtU0Fleaf)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611111275) (:text "|\"\\\\") (:id |0NV6zs9WeM)
+                                        :id |RQxFTpR9Rk
+                                      |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611101358)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611103307) (:text |is+) (:id |9Ha9HtU0Fleaf)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611114851) (:text "|\"\\n") (:id |0NV6zs9WeM)
+                                        :id |Yem2E-X67
+                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611131501) (:text |[]) (:id |bqGv6M7CLXleaf)
+                                    :id |_eSvJFWRe
+                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611133849) (:text |or+) (:id |VDCY4nZsKE)
+                                :id |Kvck6slyo
+                            :id |LNO70h2jO
+                        :id |WET625bddW
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588681050873)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681052081) (:text |xs) (:id |NEGfH2KAR0)
-                        :id |GTaQ4dQiuN
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588681056314)
-                        :data $ {}
-                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588681052613)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681051174) (:text |fn) (:id |eiXXVeZ9_Bleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588681051509)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681053675) (:text |nth) (:id |dUtIEKkUJwleaf)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681054532) (:text |xs) (:id |dB1ylhtKt)
-                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681055598) (:text |1) (:id |u5u4pwrv31)
-                            :id |dUtIEKkUJw
-                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681059302) (:text |string/join) (:id |4ZL7PoUX7w)
-                          |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681059678) (:text "|\"") (:id |hCbT7Nnkz0)
-                        :id |bMPppY_JGO
-                    :id |eiXXVeZ9_B
-                :id |zp8KZUg6yz
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681052081) (:text |xs) (:id |NEGfH2KAR0)
+                            :id |GTaQ4dQiuN
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588681056314)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588681052613)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681053675) (:text |nth) (:id |dUtIEKkUJwleaf)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681054532) (:text |xs) (:id |dB1ylhtKt)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681055598) (:text |1) (:id |u5u4pwrv31)
+                                :id |dUtIEKkUJw
+                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681059302) (:text |string/join) (:id |4ZL7PoUX7w)
+                              |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588681059678) (:text "|\"") (:id |hCbT7Nnkz0)
+                            :id |bMPppY_JGO
+                        :id |eiXXVeZ9_B
+                    :id |zp8KZUg6yz
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869114766) (:text |label+) (:id |-zmrJ-Uju)
+                  |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869119531) (:text "|\"string") (:id |qZidAXDcwU)
+                :id |3JQRYzPNct
             :id |nvORsrS05z
           |array-parser+ $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611299951)
             :data $ {}
@@ -3897,44 +4166,49 @@
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611222354) (:text |def) (:id |uqCyFzLtpQ)
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611220405) (:text |boolean-parser) (:id |LThXAjYHx8)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611220405)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869130431)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611228214) (:text |or+) (:id |nrDf7Ghut4)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611226253)
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611220405)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611226446) (:text |[]) (:id |n_aCZrgNV)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611230443)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611228214) (:text |or+) (:id |nrDf7Ghut4)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611226253)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611230744) (:text |is+) (:id |pNtzjXJ3m3)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611232805) (:text "|\"true") (:id |kza1FTgJA)
-                        :id |L7Rhsr32KY
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611230443)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611230744) (:text |is+) (:id |pNtzjXJ3m3)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611235685) (:text "|\"false") (:id |kza1FTgJA)
-                        :id |COvMSfr2WN
-                    :id |k269D5ITIO
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588678098253)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678099324) (:text |fn) (:id |1bXNOZPfBleaf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588678100228)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678100469) (:text |x) (:id |R9QtMbnIQ)
-                        :id |StJ0gv7l-A
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588678101128)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678106091) (:text |if) (:id |0VSOTlbeTleaf)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588678107136)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611226446) (:text |[]) (:id |n_aCZrgNV)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611230443)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678107720) (:text |=) (:id |CKOOWp7xmb)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678108012) (:text |x) (:id |yIFC9PAZsT)
-                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678111705) (:text "|\"true") (:id |TvvK_JBkY)
-                            :id |u5xnTFwOr
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678113161) (:text |true) (:id |dmV8o0stg)
-                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678114321) (:text |false) (:id |ZULaW80F5S)
-                        :id |0VSOTlbeT
-                    :id |1bXNOZPfB
-                :id |TFVIb2MHPE
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611230744) (:text |is+) (:id |pNtzjXJ3m3)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611232805) (:text "|\"true") (:id |kza1FTgJA)
+                            :id |L7Rhsr32KY
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611230443)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611230744) (:text |is+) (:id |pNtzjXJ3m3)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611235685) (:text "|\"false") (:id |kza1FTgJA)
+                            :id |COvMSfr2WN
+                        :id |k269D5ITIO
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588678098253)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678099324) (:text |fn) (:id |1bXNOZPfBleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588678100228)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678100469) (:text |x) (:id |R9QtMbnIQ)
+                            :id |StJ0gv7l-A
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588678101128)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678106091) (:text |if) (:id |0VSOTlbeTleaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588678107136)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678107720) (:text |=) (:id |CKOOWp7xmb)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678108012) (:text |x) (:id |yIFC9PAZsT)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678111705) (:text "|\"true") (:id |TvvK_JBkY)
+                                :id |u5xnTFwOr
+                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678113161) (:text |true) (:id |dmV8o0stg)
+                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678114321) (:text |false) (:id |ZULaW80F5S)
+                            :id |0VSOTlbeT
+                        :id |1bXNOZPfB
+                    :id |TFVIb2MHPE
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869132288) (:text |label+) (:id |-xsDAWo6SD)
+                  |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869134323) (:text "|\"boolean") (:id |1KelArvsdD)
+                :id |YlnO_AuZtQ
             :id |sxDXRMxKmF
           |demo-parser $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588589295619)
             :data $ {}
@@ -3954,105 +4228,115 @@
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610652819) (:text |def) (:id |ucdLcGuRep)
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588589994825) (:text |number-parser) (:id |nitPFbtOBe)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588589994825)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867655842)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610658347) (:text |combine+) (:id |dZhJjHhI9B)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610665052)
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588589994825)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610665539) (:text |[]) (:id |qTzhkCcxX)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610700504)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610658347) (:text |combine+) (:id |dZhJjHhI9B)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610665052)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610692723) (:text |digit-parser) (:id |r68bMrLD6L)
-                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610702557) (:text |many+) (:id |08QOLmchyM)
-                        :id |lTi7mcH-x
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610704068)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610707357) (:text |optional+) (:id |I8mAKngLhleaf)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610715583)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610665539) (:text |[]) (:id |qTzhkCcxX)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610700504)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610719497) (:text |combine+) (:id |WLiF0zdyo)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610720475)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610692723) (:text |digit-parser) (:id |r68bMrLD6L)
+                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610702557) (:text |many+) (:id |08QOLmchyM)
+                            :id |lTi7mcH-x
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610704068)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610707357) (:text |optional+) (:id |I8mAKngLhleaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610715583)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610720680) (:text |[]) (:id |G1O2nK6oZ)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610722629)
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610719497) (:text |combine+) (:id |WLiF0zdyo)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610720475)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610723168) (:text |is+) (:id |jAhHtxC9P)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610724400) (:text "|\".") (:id |tKY5Prkl3p)
-                                    :id |POwn6mxwb
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610734264)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610734264) (:text |many+) (:id |K9xT5Lw72f)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610734264) (:text |digit-parser) (:id |yEGuOjAK5Q)
-                                    :id |gIpA_Syn76
-                                :id |15mpSUHV3I
-                            :id |xUCEXcKWpb
-                        :id |I8mAKngLh
-                      |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610887639)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610887639) (:text |optional+) (:id |_MNkrGP-mO)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610887639)
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610720680) (:text |[]) (:id |G1O2nK6oZ)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610722629)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610723168) (:text |is+) (:id |jAhHtxC9P)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610724400) (:text "|\".") (:id |tKY5Prkl3p)
+                                        :id |POwn6mxwb
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610734264)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610734264) (:text |many+) (:id |K9xT5Lw72f)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610734264) (:text |digit-parser) (:id |yEGuOjAK5Q)
+                                        :id |gIpA_Syn76
+                                    :id |15mpSUHV3I
+                                :id |xUCEXcKWpb
+                            :id |I8mAKngLh
+                          |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610887639)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610887639) (:text |is+) (:id |rzWRHUd4Sw)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610887639) (:text "|\"-") (:id |8my44Pus0f)
-                            :id |fOS_08Iivg
-                        :id |gs4qIkfEwt
-                    :id |kp1RgZI3KR
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680702764)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680703077) (:text |fn) (:id |vtTjmHtHDrleaf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680705199)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680714947) (:text |xs) (:id |h2SqFsOu4r)
-                        :id |NcYTUbfBv
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680937860)
-                        :data $ {}
-                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680727515)
-                            :data $ {}
-                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680707486)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610887639) (:text |optional+) (:id |_MNkrGP-mO)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588610887639)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680709812) (:text |nth) (:id |1eYnZV0vC)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680713560) (:text |xs) (:id |dXKOERL7CF)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680712628) (:text |1) (:id |VjJp7CrlWb)
-                                :id |wSizD-z9G
-                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680729927) (:text |string/join) (:id |Rfdw965T6q)
-                              |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680753094) (:text "|\"") (:id |MKcLCn1Zwq)
-                            :id |iTQwMgKp4m
-                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680940637) (:text |js/Number) (:id |QGvBWTke_)
-                        :id |grBwVZPEH-
-                    :id |vtTjmHtHDr
-                :id |Xc1POb5FbD
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610887639) (:text |is+) (:id |rzWRHUd4Sw)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610887639) (:text "|\"-") (:id |8my44Pus0f)
+                                :id |fOS_08Iivg
+                            :id |gs4qIkfEwt
+                        :id |kp1RgZI3KR
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680702764)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680703077) (:text |fn) (:id |vtTjmHtHDrleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680705199)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680714947) (:text |xs) (:id |h2SqFsOu4r)
+                            :id |NcYTUbfBv
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680937860)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680727515)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588680707486)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680709812) (:text |nth) (:id |1eYnZV0vC)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680713560) (:text |xs) (:id |dXKOERL7CF)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680712628) (:text |1) (:id |VjJp7CrlWb)
+                                    :id |wSizD-z9G
+                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680729927) (:text |string/join) (:id |Rfdw965T6q)
+                                  |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680753094) (:text "|\"") (:id |MKcLCn1Zwq)
+                                :id |iTQwMgKp4m
+                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588680940637) (:text |js/Number) (:id |QGvBWTke_)
+                            :id |grBwVZPEH-
+                        :id |vtTjmHtHDr
+                    :id |Xc1POb5FbD
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867658648) (:text |label+) (:id |ExEel5062)
+                  |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869143309) (:text "|\"number") (:id |A1hZfP51zz)
+                :id |RjDhmAHTtR
             :id |aJX_QcHj4X
           |nil-parser $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611246519)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611248850) (:text |def) (:id |WPwyVP1MSx)
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611246519) (:text |nil-parser) (:id |f-MKcPEKNA)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611246519)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869160662)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611251045) (:text |or+) (:id |rwQ3obJM4n)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611251396)
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611246519)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611253398) (:text |[]) (:id |8G1P_EmtVf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611258137)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611251045) (:text |or+) (:id |rwQ3obJM4n)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611251396)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611260017) (:text |is+) (:id |szNnn_shUh)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611262036) (:text "|\"null") (:id |LV7wWXEgA)
-                        :id |Xrm974SE4
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611258137)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611253398) (:text |[]) (:id |8G1P_EmtVf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611258137)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611260017) (:text |is+) (:id |szNnn_shUh)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611262036) (:text "|\"null") (:id |LV7wWXEgA)
+                            :id |Xrm974SE4
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611258137)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611260017) (:text |is+) (:id |szNnn_shUh)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611266283) (:text "|\"undefined") (:id |LV7wWXEgA)
+                            :id |cPF6LRgiV
+                        :id |f5vWWFYbMi
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588677905311)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611260017) (:text |is+) (:id |szNnn_shUh)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588611266283) (:text "|\"undefined") (:id |LV7wWXEgA)
-                        :id |cPF6LRgiV
-                    :id |f5vWWFYbMi
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588677905311)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588677907193) (:text |fn) (:id |etZtDLtkWleaf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588677907460)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588677907767) (:text |x) (:id |gzwe43oDRt)
-                        :id |z-2OyhHRaY
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678089312) (:text |nil) (:id |gzV7nmv-G0)
-                    :id |etZtDLtkW
-                :id |GPa1snNMog
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588677907193) (:text |fn) (:id |etZtDLtkWleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588677907460)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588677907767) (:text |x) (:id |gzwe43oDRt)
+                            :id |z-2OyhHRaY
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588678089312) (:text |nil) (:id |gzV7nmv-G0)
+                        :id |etZtDLtkW
+                    :id |GPa1snNMog
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869163066) (:text |label+) (:id |rSemC4VWCM)
+                  |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869165151) (:text "|\"nil") (:id |2zU9WpOOis)
+                :id |ybcxAOGr4n
             :id |_KhBRIQiQK
         :proc $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588583128833) (:data $ {}) (:id |N6N9blNt0h)
         :configs $ {}
@@ -4498,7 +4782,7 @@
                                                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584255399903)
                                                     :data $ {}
                                                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584255403369) (:text |:padding-bottom) (:id |x-nMOfDeY)
-                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584255408583) (:text |600) (:id |Cp1DcduFX)
+                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869216620) (:text |400) (:id |Cp1DcduFX)
                                                     :id |T4eRkuF4L
                                                 :id |jvpA3Wf5j
                                             :id |CRgHj1Vmf
@@ -4873,7 +5157,7 @@
                               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249636517)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249637107) (:text |<>) (:id |kO6gLiHZ0)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249639957) (:text "|\"OK") (:id |SdfrwpTMC)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869497742) (:text "|\"Ok") (:id |SdfrwpTMC)
                                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249706867)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249706867) (:text |merge) (:id |05jzCA_Q1)
@@ -4903,7 +5187,7 @@
                               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249636517)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249637107) (:text |<>) (:id |kO6gLiHZ0)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249662553) (:text "|\"Failure") (:id |SdfrwpTMC)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869478448) (:text "|\"Fail") (:id |SdfrwpTMC)
                                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249681253)
                                     :data $ {}
                                       |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249645075)
@@ -4915,9 +5199,9 @@
                                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249702047)
                                                 :data $ {}
                                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249702047) (:text |hsl) (:id |_ladFmyh9)
-                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249702047) (:text |60) (:id |RDAHI-p72)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868354869) (:text |20) (:id |RDAHI-p72)
                                                   |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249702047) (:text |80) (:id |peet2MjTq)
-                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249726832) (:text |40) (:id |osGPOHpr2)
+                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868365242) (:text |50) (:id |osGPOHpr2)
                                                 :id |4u0WaD0zi
                                             :id |sMcv6c7qD
                                           |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252392391)
@@ -4978,49 +5262,63 @@
                                   |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584255494227) (:text |node) (:id |Ta7fAss4u)
                                 :id |tnQQG04Vx
                             :id |XJbvv7Lj
-                          |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252331264)
+                          |r5 $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868218680)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252337122) (:text |if-not) (:id |IEyDcaGxleaf)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252333372)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868220028) (:text |if) (:id |MK5jk35e6leaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869729163)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252339678) (:text |:ok?) (:id |neYg_31zH)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252340409) (:text |node) (:id |_bO01ACdV)
-                                :id |Zj4AM5Et
-                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252341231)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252341860) (:text |<>) (:id |2ihAzCIbleaf)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252343693)
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868224915)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252346980) (:text |:message) (:id |KE4czDaI)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252348788) (:text |node) (:id |R9mjJJeI)
-                                    :id |y91HWBP1a
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252355682)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252355682) (:text |merge) (:id |3woW5zZXH)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252355682) (:text |style-label) (:id |eoSS-hMYJ)
-                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252355682)
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868220316)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252355682) (:text |{}) (:id |7oE5uA8n5)
-                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252355682)
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868223298) (:text |:parser-node) (:id |38Rb5l1Zg)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868224257) (:text |node) (:id |GKzibzA-jv)
+                                        :id |boviS_FpPZ
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868225715) (:text |=) (:id |CL1ZIirJq)
+                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868227593) (:text |:label) (:id |61UJjDZHLI)
+                                    :id |gb14-WdBpk
+                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869729741) (:text |or) (:id |rfPebKcbHH)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868224915)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868220316)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868223298) (:text |:parser-node) (:id |38Rb5l1Zg)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868224257) (:text |node) (:id |GKzibzA-jv)
+                                        :id |boviS_FpPZ
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868225715) (:text |=) (:id |CL1ZIirJq)
+                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869734550) (:text |:component) (:id |61UJjDZHLI)
+                                    :id |yHtebwvJSr
+                                :id |_uzwJ7enX
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868229405)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868232133) (:text |<>) (:id |aD2_FLL0Ql)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868232527)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868235507) (:text |:label) (:id |H4qPlFLC_K)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868236047) (:text |node) (:id |hB6VRk1B9k)
+                                    :id |lUG01rMUuM
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868248395)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868248395) (:text |merge) (:id |3E2sYKgjcM)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868248395) (:text |style-label) (:id |q0kmRykbcE)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868248395)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868248395) (:text |{}) (:id |WHRB0Qby6S)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868248395)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252355682) (:text |:background-color) (:id |AgMbZ5SQT)
-                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252355682)
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868248395) (:text |:background-color) (:id |HxtITG9Zjy)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868248395)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252355682) (:text |hsl) (:id |mIMsq8jjO)
-                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252358405) (:text |0) (:id |x0CvDw9Zt)
-                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252355682) (:text |80) (:id |KHPZoOGSf)
-                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252360264) (:text |60) (:id |C7obgkVY2)
-                                                :id |2Oct_1kNM
-                                            :id |OY5XgHywM
-                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252366493)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252371295) (:text |:font-family) (:id |D20UdpeAQleaf)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252380826) (:text |ui/font-normal) (:id |ZOhLDj4bE)
-                                            :id |D20UdpeAQ
-                                        :id |-S5NPx-Ar
-                                    :id |-CPrNEC3u
-                                :id |2ihAzCIb
-                            :id |IEyDcaGx
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868248395) (:text |hsl) (:id |12jYrY5LC9)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869193483) (:text |200) (:id |YP5F4kxnk1)
+                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869195961) (:text |90) (:id |iN8qIUUlo_)
+                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869183767) (:text |60) (:id |xXFNRkKAtK)
+                                                :id |G8aDul1jKd
+                                            :id |iIWzoaL8PG
+                                        :id |5GdybOXpVY
+                                    :id |b7U0cGng0i
+                                :id |IH1gRCsHn
+                            :id |MK5jk35e6
                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249190977)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249193429) (:text |{}) (:id |o8RpTkvQb)
@@ -5067,7 +5365,7 @@
                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249717528) (:text |hsl) (:id |2wF89u3sJ)
                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252098810) (:text |100) (:id |Stvi-BT2u)
                                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584253234992) (:text |10) (:id |nVdBZtjxb)
-                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584253238725) (:text |60) (:id |uVmitgerg)
+                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869862946) (:text |70) (:id |uVmitgerg)
                                             :id |W8Jurk0Kk
                                         :id |q8O2Z3yS5
                                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584252132824)
@@ -5086,11 +5384,15 @@
                           |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249193805)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249194122) (:text |<>) (:id |AAc-oX_n1leaf)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249199693)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869522302)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249221646) (:text |:parser-node) (:id |qlj_okM2m)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249202303) (:text |node) (:id |X9Ng-V2q)
-                                :id |mrZkH1vOY
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249199693)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249221646) (:text |:parser-node) (:id |qlj_okM2m)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249202303) (:text |node) (:id |X9Ng-V2q)
+                                    :id |mrZkH1vOY
+                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869523905) (:text |name) (:id |oTGTjAwQ6R)
+                                :id |3EULbKfgiM
                               |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249714891)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249714891) (:text |merge) (:id |6GP5_X5Op)
@@ -5106,9 +5408,14 @@
                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249717528) (:text |hsl) (:id |2wF89u3sJ)
                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249717528) (:text |200) (:id |Stvi-BT2u)
                                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249717528) (:text |80) (:id |nVdBZtjxb)
-                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249717528) (:text |70) (:id |uVmitgerg)
+                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869547963) (:text |76) (:id |uVmitgerg)
                                             :id |W8Jurk0Kk
                                         :id |q8O2Z3yS5
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588869526756)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869526756) (:text |:font-family) (:id |je30DTBPRx)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588869526756) (:text |ui/font-fancy) (:id |IA0yuDV8zS)
+                                        :id |1zTSkadA0z
                                     :id |m5MNK0MBW
                                 :id |LATdpn2b_
                             :id |AAc-oX_n1
@@ -5243,19 +5550,66 @@
                                   |f $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584255796450) (:text |:minus) (:id |w64eWV7GL)
                                 :id |zTsm0gRy
                             :id |Mn100J9l
+                          |rD $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867875434)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |if-not) (:id |pkUbce75K3)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867875434)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |:ok?) (:id |3OKg6SpBqY)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |node) (:id |aUUGHWiTop)
+                                :id |z_LUzdslE5
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867875434)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |<>) (:id |8gj7-ORHWR)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867875434)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |:message) (:id |DmmvqEckGL)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |node) (:id |4BZBWUxjVB)
+                                    :id |HTCjhtOuOR
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867875434)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |merge) (:id |xEvMfkwrTv)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |style-label) (:id |z3sQ9mpH1l)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867875434)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |{}) (:id |h708WlZt-J)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867875434)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |:background-color) (:id |xx3zKTrwO_n)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867875434)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |hsl) (:id |rIqIvT7K_uD)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |0) (:id |ft6vgqX3ecV)
+                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |80) (:id |4XhykIdBH7K)
+                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867875434) (:text |60) (:id |0xaMFHc4rfn)
+                                                :id |MoB6N3skvai
+                                            :id |UYeFWMr-wNb
+                                        :id |nAntZX7402
+                                    :id |ODd4FDBvL-
+                                :id |Nzza7U5D6s
+                            :id |0qBpaugvOW
                           |rT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584254949199)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254950165) (:text |if) (:id |-A3qPdzvleaf)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584254951304)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867957165)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254951136) (:text |=) (:id |MRGzIdtAC)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254954765) (:text |:is) (:id |Ouz4FXA_)
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584254959993)
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584254951304)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254980037) (:text |:parser-node) (:id |_6fXOisN)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254963064) (:text |node) (:id |XK2zbfd4)
-                                    :id |JkzaW1O9W
-                                :id |vG8gI0H86
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254951136) (:text |=) (:id |MRGzIdtAC)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254954765) (:text |:is) (:id |Ouz4FXA_)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584254959993)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254980037) (:text |:parser-node) (:id |_6fXOisN)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254963064) (:text |node) (:id |XK2zbfd4)
+                                        :id |JkzaW1O9W
+                                    :id |vG8gI0H86
+                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867958671) (:text |and) (:id |VMxM3eEJwb)
+                                  |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588867959024)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867960218) (:text |:ok?) (:id |zfv4FCfaBM)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588867962291) (:text |node) (:id |rqVRZ9BdKe)
+                                    :id |QlT5bIuR8h
+                                :id |zwITKSfFU
                               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584254964600)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584254964989) (:text |<>) (:id |aLCaFeFxleaf)
@@ -5622,8 +5976,13 @@
                   |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249690517)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249690517) (:text |:line-height) (:id |LhGQ1mfD7k)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584252409979) (:text "|\"24px") (:id |SOBfHA7Dvk)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868395964) (:text "|\"22px") (:id |SOBfHA7Dvk)
                     :id |re8U08QFvf
+                  |yy $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588868379009)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868381748) (:text |:font-size) (:id |7mJUHuyrvvleaf)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868382385) (:text |13) (:id |LB6s6k4DCq)
+                    :id |7mJUHuyrvv
                   |yv $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584255027014)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584255030403) (:text |:white-space) (:id |c6vqups8Cleaf)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -2601,56 +2601,6 @@
                         :id |K3RUhqmgL
                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584204726303)
                         :data $ {}
-                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584207852179)
-                            :data $ {}
-                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584207856001)
-                                :data $ {}
-                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584197792183)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584197793471) (:text |empty?) (:id |tA8uLd6PO)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584197793950) (:text |xs) (:id |RjQQE8VSp)
-                                    :id |8koW56dD
-                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584207857646) (:text |and) (:id |KHCozX1J)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584207858191)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584207875716) (:text |not) (:id |QenDN1cFleaf)
-                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584207865136)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584207867813) (:text |empty?) (:id |PrSIx2SSw)
-                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584207868183) (:text |ys) (:id |EJHLo4n-y)
-                                        :id |VK2kzoxn
-                                    :id |QenDN1cF
-                                :id |ud_2NbS7y
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584197795220)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584197795531) (:text |{}) (:id |bswQd2VPA)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584197798300)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584197799374) (:text |:ok?) (:id |MDkRY8Gt)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584204788892) (:text |false) (:id |nnZxmw0xZ)
-                                    :id |8rOaeUsxN
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584197800579)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584197803577) (:text |:results) (:id |S38LXOe1qleaf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584197805224) (:text |acc) (:id |k79aKvQww)
-                                    :id |S38LXOe1q
-                                  |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584204793599)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584204795009) (:text |:message) (:id |Ue-phWaLleaf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588868797107) (:text "|\"unexpected EOF") (:id |PqG5lPyl)
-                                    :id |Ue-phWaL
-                                  |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584206047325)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584206047325) (:text |:parser-node) (:id |4l5lTC-xQ)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584206047325) (:text |:combine) (:id |LLxUmfFem)
-                                    :id |WZ1KIzhEd
-                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584256047863)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584256047863) (:text |:rest) (:id |i_tAbKBAu)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584256047863) (:text |xs) (:id |Hh3H-oWN1)
-                                    :id |CZrrkZRtT
-                                :id |yqtPDRx4
-                            :id |FUtQMaI9
                           |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584204729181) (:text |cond) (:id |Zy6hVsItt)
                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584204732642)
                             :data $ {}
@@ -4903,10 +4853,10 @@
                                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194603171) (:text "|\"") (:id |AHE5N6pjK)
                                                             :id |J14nY_KJ
                                                           |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194179524) (:text |parse-lilac) (:id |Hi9fQ83yW)
-                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588611822885)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588870672983)
                                                             :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588612405639) (:text |value-parser+) (:id |27unqKPhEy)
-                                                            :id |2aLnXlqq1
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588870679152) (:text |value-parser+) (:id |27unqKPhEy)
+                                                            :id |Xq3R7iqVn8
                                                         :id |CJKZsEmV
                                                     :id |qY4W0BuYEi
                                                 :id |pBVZ8MzxK

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvc-works/lilac-parser",
-  "version": "0.0.2-a2",
+  "version": "0.0.2-a3",
   "description": "Toy parser in cljs",
   "main": "index.js",
   "scripts": {

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.0.2-a2"
+{:version "0.0.2-a3"
  :group-id "mvc-works"
  :artifact-id "lilac-parser"
  :skip-tag true

--- a/src/lilac_parser/comp/container.cljs
+++ b/src/lilac_parser/comp/container.cljs
@@ -25,12 +25,13 @@
   {:font-family ui/font-code,
    :color (hsl 0 0 100),
    :display :inline-block,
-   :line-height "24px",
+   :line-height "22px",
    :padding "0 4px",
    :border-radius "4px",
    :margin-right 8,
    :white-space :pre,
-   :min-height 14})
+   :min-height 14,
+   :font-size 13})
 
 (defcomp
  comp-node
@@ -62,17 +63,19 @@
         (fn [e d!] )))
      (if (:ok? node)
        (<>
-        "OK"
+        "Ok"
         (merge style-label {:background-color (hsl 200 80 70), :font-family ui/font-fancy}))
        (<>
-        "Failure"
-        (merge style-label {:background-color (hsl 60 80 40), :font-family ui/font-fancy})))
+        "Fail"
+        (merge style-label {:background-color (hsl 20 80 50), :font-family ui/font-fancy})))
+     (<>
+      (name (:parser-node node))
+      (merge style-label {:background-color (hsl 200 80 76), :font-family ui/font-fancy}))
+     (if (or (= :label (:parser-node node)) (= :component (:parser-node node)))
+       (<> (:label node) (merge style-label {:background-color (hsl 200 90 60)})))
      (if-not (:ok? node)
-       (<>
-        (:message node)
-        (merge style-label {:background-color (hsl 0 80 60), :font-family ui/font-normal})))
-     (<> (:parser-node node) (merge style-label {:background-color (hsl 200 80 70)}))
-     (if (= :is (:parser-node node))
+       (<> (:message node) (merge style-label {:background-color (hsl 0 80 60)})))
+     (if (and (:ok? node) (= :is (:parser-node node)))
        (<> (:value node) (merge style-label {:background-color (hsl 200 80 70)})))
      (if (:ok? node)
        (<>
@@ -80,7 +83,7 @@
         (merge style-label {:background-color (hsl 200 80 80), :font-size 10})))
      (<>
       (->> (:rest node) (take 10) (string/join ""))
-      (merge style-label {:background-color (hsl 100 10 60), :font-size 10, :min-height 16})))
+      (merge style-label {:background-color (hsl 100 10 70), :font-size 10, :min-height 16})))
     (if (and has-children? (not (:folded? state)))
       (div
        {}
@@ -135,7 +138,7 @@
        :on-input (fn [e d!] (d! cursor (assoc state :code (:value e))))})
      (if (:gui? state)
        (div
-        {:style (merge ui/expand {:padding-bottom 600})}
+        {:style (merge ui/expand {:padding-bottom 400})}
         (comp-node (>> states :tree-viewer) (:result state)))
        (textarea
         {:style (merge

--- a/src/lilac_parser/core.cljs
+++ b/src/lilac_parser/core.cljs
@@ -263,12 +263,6 @@
   (let [items (:items rule), transform (:transform rule)]
     (loop [acc [], xs xs0, ys items]
       (cond
-        (and (empty? xs) (not (empty? ys)))
-          {:ok? false,
-           :message "unexpected EOF",
-           :parser-node :combine,
-           :results acc,
-           :rest xs}
         (empty? ys)
           {:ok? true,
            :value (let [v (map :value acc)] (if (some? transform) (transform v) v)),

--- a/src/lilac_parser/demo/json.cljs
+++ b/src/lilac_parser/demo/json.cljs
@@ -11,7 +11,8 @@
               one-of+
               some+
               or+
-              defparser]]
+              defparser
+              label+]]
             [clojure.string :as string]))
 
 (declare value-parser+)
@@ -21,29 +22,34 @@
 (declare object-parser+)
 
 (def boolean-parser
-  (or+ [(is+ "true") (is+ "false")] (fn [x] (if (= x "true") true false))))
+  (label+ "boolean" (or+ [(is+ "true") (is+ "false")] (fn [x] (if (= x "true") true false)))))
 
 (def space-parser (some+ (is+ " ") (fn [x] nil)))
 
-(def comma-parser (combine+ [space-parser (is+ ",") space-parser] (fn [x] nil)))
+(def comma-parser
+  (label+ "comma" (combine+ [space-parser (is+ ",") space-parser] (fn [x] nil))))
 
 (def digit-parser (one-of+ "1234567890"))
 
-(def nil-parser (or+ [(is+ "null") (is+ "undefined")] (fn [x] nil)))
+(def nil-parser (label+ "nil" (or+ [(is+ "null") (is+ "undefined")] (fn [x] nil))))
 
 (def number-parser
-  (combine+
-   [(optional+ (is+ "-"))
-    (many+ digit-parser)
-    (optional+ (combine+ [(is+ ".") (many+ digit-parser)]))]
-   (fn [xs] (js/Number (string/join "" (nth xs 1))))))
+  (label+
+   "number"
+   (combine+
+    [(optional+ (is+ "-"))
+     (many+ digit-parser)
+     (optional+ (combine+ [(is+ ".") (many+ digit-parser)]))]
+    (fn [xs] (js/Number (string/join "" (nth xs 1)))))))
 
 (def string-parser
-  (combine+
-   [(is+ "\"")
-    (some+ (or+ [(other-than+ "\"\\") (is+ "\\\"") (is+ "\\\\") (is+ "\\n")]))
-    (is+ "\"")]
-   (fn [xs] (string/join "" (nth xs 1)))))
+  (label+
+   "string"
+   (combine+
+    [(is+ "\"")
+     (some+ (or+ [(other-than+ "\"\\") (is+ "\\\"") (is+ "\\\\") (is+ "\\n")]))
+     (is+ "\"")]
+    (fn [xs] (string/join "" (nth xs 1))))))
 
 (defparser
  value-parser+


### PR DESCRIPTION
By introducing `label+` node, output tree got more marks and looks more comprehensible:

![image](https://user-images.githubusercontent.com/449224/81321923-c5d13280-90c5-11ea-9a4c-1f53a1217b2c.png)
