### PR TITLE
Adding replace-lilac

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Try with `(def a (add 1 2))` or `{"json": [1, 2]}`.
 [![Clojars Project](https://img.shields.io/clojars/v/mvc-works/lilac-parser.svg)](https://clojars.org/mvc-works/lilac-parser)
 
 ```edn
-[mvc-works/lilac-parser "0.0.3-a3"]
+[mvc-works/lilac-parser "0.0.3-a4"]
 ```
 
 ```clojure
 (require '[lilac-parser.core :refer
             [parse-lilac defparser is+ many+ one-of+ other-than+
              some+ combine+ interleave+ label+
-             replace-lilac]])
+             replace-lilac find-lilac]])
 
 (parse-lilac (string/split "aaaa" "") (many+ (is+ "a")))
 ```
@@ -172,6 +172,12 @@ which returns `:result` as well as parsing details in `:attempts`:
 ```
 
 This is an experimental API serving jobs as a custom regular expression replacer.
+
+Similarly matched pieces can be collected with `find-lilac`:
+
+```clojure
+(find-lilac (string/split content "") rule)
+```
 
 ### Workflow
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Try with `(def a (add 1 2))` or `{"json": [1, 2]}`.
 [![Clojars Project](https://img.shields.io/clojars/v/mvc-works/lilac-parser.svg)](https://clojars.org/mvc-works/lilac-parser)
 
 ```edn
-[mvc-works/lilac-parser "0.0.3-a2"]
+[mvc-works/lilac-parser "0.0.3-a3"]
 ```
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Lilac parser
 
-> A toy combinator parser with better failure reasons.
+> A toy DSL-based combinator parser with better failure reasons.
 
 Online demo http://repo.mvc-works.org/lilac-parser/
 
@@ -11,13 +11,14 @@ Try with `(def a (add 1 2))` or `{"json": [1, 2]}`.
 [![Clojars Project](https://img.shields.io/clojars/v/mvc-works/lilac-parser.svg)](https://clojars.org/mvc-works/lilac-parser)
 
 ```edn
-[mvc-works/lilac-parser "0.0.3-a1"]
+[mvc-works/lilac-parser "0.0.3-a2"]
 ```
 
 ```clojure
 (require '[lilac-parser.core :refer
             [parse-lilac defparser is+ many+ one-of+ other-than+
-             some+ combine+ interleave+ label+]])
+             some+ combine+ interleave+ label+
+             replace-lilac]])
 
 (parse-lilac (string/split "aaaa" "") (many+ (is+ "a")))
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Try with `(def a (add 1 2))` or `{"json": [1, 2]}`.
 [![Clojars Project](https://img.shields.io/clojars/v/mvc-works/lilac-parser.svg)](https://clojars.org/mvc-works/lilac-parser)
 
 ```edn
-[mvc-works/lilac-parser "0.0.2-a3"]
+[mvc-works/lilac-parser "0.0.3-a1"]
 ```
 
 ```clojure
@@ -19,7 +19,7 @@ Try with `(def a (add 1 2))` or `{"json": [1, 2]}`.
             [parse-lilac defparser is+ many+ one-of+ other-than+
              some+ combine+ interleave+ label+]])
 
-(parse-lilac "aaaa" (many+ (is+ "a")))
+(parse-lilac (string/split "aaaa" "") (many+ (is+ "a")))
 ```
 
 Demo of a stupid S-expression parser:
@@ -150,6 +150,27 @@ Parser rules can be expected by injecting functions. It could be quite tricky an
   ; TODO
   )
 ```
+
+### Replacer
+
+A function is also provided for replacing text pieces matching a given rule:
+
+```clojure
+(replace-lilac (string/split content "") rule (fn [x] (str "<<<" x ">>>>")))
+```
+
+which returns `:result` as well as parsing details in `:attempts`:
+
+```edn
+{
+  :result "<<<MATCHED>>>>"
+  :attempts [
+    ; parsing summaries in vector
+  ]
+}
+```
+
+This is an experimental API serving jobs as a custom regular expression replacer.
 
 ### Workflow
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1733,6 +1733,160 @@
                     :id |1QXX9dD72c
                 :id |t5DrGc4nK
             :id |Ba9GSqmo19
+          |replace-lilac $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412104754)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412283857) (:text |defn$) (:id |gIj9c01cAe)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412104754) (:text |replace-lilac) (:id |_oZegrfhJQ)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412285390)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412104754)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412201200) (:text |content) (:id |LBxB6gzCI)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412203467) (:text |rule) (:id |Avcx7W0C3)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412264615) (:text |replacer) (:id |o-RXtrDby)
+                    :id |RDluOATte_
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412286107)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412291229) (:text |replace-lilac) (:id |glrcgBD5ah)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412727078) (:text "|\"") (:id |KJ0Vc9WsvC)
+                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412295989) (:text |rule) (:id |G-Xh6NlRS)
+                      |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412298903) (:text |replacer) (:id |Ta6WREo2a)
+                      |p $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412636276) (:text |content) (:id |xivZ7xz1Nk)
+                      |m $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416172872)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416173045) (:text |[]) (:id |c_ITFIDaun)
+                        :id |v2Fj78KXDX
+                    :id |ApQSI2-uA
+                :id |FZI7EFIHJe
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412285390)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412104754)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412201200) (:text |content) (:id |LBxB6gzCI)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412203467) (:text |rule) (:id |Avcx7W0C3)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412264615) (:text |replacer) (:id |o-RXtrDby)
+                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412305388) (:text |acc) (:id |jpK3gLjfw)
+                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416178302) (:text |attempts) (:id |49GmKmQRSc)
+                    :id |RDluOATte_
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412308264)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412308823) (:text |if) (:id |FGLEHxyCSleaf)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412309726)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412310876) (:text |empty?) (:id |WRwVjdZXP3)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412318545) (:text |content) (:id |lfgUcgPaWH)
+                        :id |dXUdIMwKk
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416157221)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416158605)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412335416) (:text |acc) (:id |slHIf4Qle)
+                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416159848) (:text |:result) (:id |EzRt5f5Luw)
+                            :id |7WXDSy-n66
+                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416158139) (:text |{}) (:id |CGuy1tQQCB)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416160295)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416167090) (:text |:attempts) (:id |yHYEd_NttUleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416223499) (:text |attempts) (:id |3rf8gfw-Ks)
+                            :id |yHYEd_NttU
+                        :id |K2mPFVzq_
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412345199)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412346988) (:text |let) (:id |M4Fy_SI3h)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412347208)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412347638)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412350058) (:text |attempt) (:id |9eN5Ex_I2o)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412350402)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412352869) (:text |parse-lilac) (:id |lhFUmBqDo)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412357736) (:text |content) (:id |uSfciEhHb)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415719978) (:text |rule) (:id |iHc7pNObgZ)
+                                    :id |_0R9hHJaXW
+                                :id |3JnK7DQIeB
+                            :id |pA9mIr6SO
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412368745)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412373469) (:text |if) (:id |EBLVEDYn4qleaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412456907)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412439312)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412426672)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412431460) (:text |replacer) (:id |5flKkFdGdf)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412437642)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412434593) (:text |:value) (:id |gH3PAPXow)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412436339) (:text |attempt) (:id |iTmtmsvVBv)
+                                            :id |3TYpCq5COx
+                                        :id |Bpx2FC63f
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412440508) (:text |str) (:id |0pya3IaW7x)
+                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412443408) (:text |acc) (:id |tQ1mMq05q)
+                                    :id |JxWU3Bf4j
+                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412457925) (:text |recur) (:id |NRNeXirjK)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412656077) (:text |rule) (:id |rjVMRwkzl)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412657934) (:text |replacer) (:id |5mpyceg94I)
+                                  |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412711540)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412712340) (:text |:rest) (:id |Y3FW4iLSo)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412716447) (:text |attempt) (:id |nRJUFwISa)
+                                    :id |tThR9EGn03
+                                  |X $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416185881)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416186627) (:text |conj) (:id |sWCrs-OhVVleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416187138) (:text |attempts) (:id |fW0JA-bqtc)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416191087) (:text |attempt) (:id |XjFhHgTCKs)
+                                    :id |sWCrs-OhVV
+                                :id |lnTTPwqAN1
+                              |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412398741)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412401794) (:text |:ok?) (:id |y76HelJvf)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412404370) (:text |attempt) (:id |7bRPvoy2uI)
+                                :id |zX6AnXgh59
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415746873)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415753467) (:text |recur) (:id |qNdU2HjuTleaf)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415754151)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415754746) (:text |str) (:id |ZbJBQaXJJ0)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415757204) (:text |acc) (:id |9VSpSgUtgz)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415757496)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415758155) (:text |first) (:id |RiORrPxOAo)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415761164) (:text |content) (:id |ylLyrfkxP)
+                                        :id |gezGhmjeKb
+                                    :id |88xYwRmnX
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415764882)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415766389) (:text |rest) (:id |WQHPnTC2Eleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415767651) (:text |content) (:id |UpNmgl8st3)
+                                    :id |WQHPnTC2E
+                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415772699) (:text |rule) (:id |eI6FAH-Yhj)
+                                  |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415773853) (:text |replacer) (:id |c7lRBIpAnb)
+                                  |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416193794)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416194355) (:text |conj) (:id |vVdvLIKwpOleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416195175) (:text |attempts) (:id |ZkrWt5pYC7)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416197764) (:text |attempt) (:id |l3LjzDiy1o)
+                                    :id |vVdvLIKwpO
+                                :id |qNdU2HjuT
+                            :id |EBLVEDYn4q
+                        :id |g7Zxy7_Vf
+                    :id |FGLEHxyCS
+                  |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412598012)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412599649) (:text |assert) (:id |qn05mICcYJleaf)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593412605257)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412611594) (:text |sequential?) (:id |SDrYQVrb2N)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412612740) (:text |content) (:id |CWmJ7gEWll)
+                        :id |sjECkBRKRU
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593412625348) (:text "|\"expects content in sequence") (:id |cXykrnNtCleaf)
+                    :id |qn05mICcYJ
+                :id |Oo9Lv6_EJ
+            :id |SMLiUktkhO
           |optional+ $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584121099445)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588676854570) (:text |defn$) (:id |nM5l61klgK)
@@ -5870,6 +6024,7 @@
                     |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584192939525)
                       :data $ {}
                         |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584192939755) (:text |[]) (:id |gWIN655bq)
+                        |n $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415624878) (:text |replace-lilac) (:id |o8VvouzKhG)
                         |yr $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205007005) (:text |one-of+) (:id |uv__a9YVI)
                         |yT $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194253660) (:text |many+) (:id |zJQSAq2PK)
                         |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584192945046) (:text |parse-lilac) (:id |PNms_EhbM)
@@ -6382,11 +6537,11 @@
                                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194120554) (:text |:value) (:id |d5ps6ZPy4leaf)
                                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584195083541)
                                             :data $ {}
-                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194127361)
+                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416457599)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194134253) (:text |:result) (:id |jbqr3FMgN)
-                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194138595) (:text |state) (:id |Lrrka2xlG)
-                                                :id |-05YG3Y6
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416457599) (:text |:result) (:id |qiaftvxS31)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416457599) (:text |state) (:id |FyUfFRxo1M)
+                                                :id |Ba6k6CcT8I
                                               |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584208743766) (:text |cirru-edn/write) (:id |ZowGtEkIH)
                                             :id |lIAQ2kaQZ
                                         :id |d5ps6ZPy4
@@ -6410,21 +6565,85 @@
                                 :id |uDH-eIZc
                               |P $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249125141)
                                 :data $ {}
-                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584247876831)
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416488554)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249140847) (:text |comp-node) (:id |I3ew9w8c2leaf)
-                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584247892531)
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584247876831)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584247892531) (:text |:result) (:id |earBEAbj-)
-                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584247892531) (:text |state) (:id |nNhRp5fpQ)
-                                        :id |lluj1Ezxx
-                                      |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1586663154984)
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249140847) (:text |comp-node) (:id |I3ew9w8c2leaf)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584247892531)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584247892531) (:text |:result) (:id |earBEAbj-)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584247892531) (:text |state) (:id |nNhRp5fpQ)
+                                            :id |lluj1Ezxx
+                                          |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1586663154984)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584247904674) (:text |states) (:id |e1CyLyrn9)
+                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1586663155625) (:text |>>) (:id |6JU-pzU_O)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1586663156292) (:text |:tree-viewer) (:id |UCYIS6TYC6)
+                                            :id |r2Uviy_-xC
+                                        :id |I3ew9w8c2
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416489107) (:text |if) (:id |c5CqAyjEzJ)
+                                      |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416492980)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584247904674) (:text |states) (:id |e1CyLyrn9)
-                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1586663155625) (:text |>>) (:id |6JU-pzU_O)
-                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1586663156292) (:text |:tree-viewer) (:id |UCYIS6TYC6)
-                                        :id |r2Uviy_-xC
-                                    :id |I3ew9w8c2
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416490705) (:text |vector?) (:id |0OVpeBAelX)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416493921)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416493921) (:text |:result) (:id |pcvx5lAlop)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416493921) (:text |state) (:id |EhMxqb0RcG)
+                                            :id |RtiasB4kyM
+                                        :id |JthDz8SiU
+                                      |P $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416495550)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416496580) (:text |list->) (:id |1JN8sf-1vleaf)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416497833)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416498128) (:text |{}) (:id |tnErgp3xx)
+                                            :id |blOX7vgYPV
+                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416498608)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416499984) (:text |->>) (:id |0Nat5G_ORVleaf)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416502110)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416502110) (:text |:result) (:id |7Q4TZQPgpd)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416502110) (:text |state) (:id |Hq6955wek0)
+                                                :id |q7jk2NbAnu
+                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416502921)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416504796) (:text |map-indexed) (:id |WAAXz2GP6Q)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416505041)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416505283) (:text |fn) (:id |QhGX7MY7j1)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416505509)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416507554) (:text |idx) (:id |oJLgwIRwaD)
+                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416511319) (:text |value) (:id |hraayFLGGc)
+                                                        :id |iby4LAFxCw
+                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416514369)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416514708) (:text |[]) (:id |mOuRbWXVdleaf)
+                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416515448) (:text |idx) (:id |K_5C38cYm9)
+                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416519747)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416519747) (:text |comp-node) (:id |Jb3XMnQE8Z)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416519747)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416519747) (:text |>>) (:id |WbTG3PUw7L)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416519747) (:text |states) (:id |OsaZ3w1zYl)
+                                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416527013)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416526453) (:text |idx) (:id |yrwiEZa6GT)
+                                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416528075) (:text |str) (:id |GFa2IPyn4)
+                                                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416535330) (:text |:tree-viewer) (:id |HCURYy7hDG)
+                                                                    :id |3tOFYGJ2Ze
+                                                                :id |Nf4Ekv1k3b
+                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416543737) (:text |value) (:id |fuq5DcqMX)
+                                                            :id |YQ-BzoLgDm
+                                                        :id |mOuRbWXVd
+                                                    :id |OqfEgtZAKf
+                                                :id |0cwzfJ_el0
+                                            :id |0Nat5G_ORV
+                                        :id |1JN8sf-1v
+                                    :id |AuW1tfynLK
                                   |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584249132485) (:text |div) (:id |kqZCwsU1k)
                                   |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584249132729)
                                     :data $ {}
@@ -6471,6 +6690,110 @@
                       |l $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191333491)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191333955) (:text |div) (:id |V5HKKD-77leaf)
+                          |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128633044)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128635373) (:text |a) (:id |Wi-i_Ygfi6leaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128635577)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128635909) (:text |{}) (:id |ZDPMQrUbGw)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128636100)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128641526) (:text |:inner-text) (:id |2WYP_OE-t9)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128643953) (:text "|\"Load EDN") (:id |2pTiqgoJkX)
+                                    :id |YZWb_9sZ2
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128644691)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128646800) (:text |:on-click) (:id |MIQsa5FHYzleaf)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128647156)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128647465) (:text |fn) (:id |nwudOSiu01)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128647620)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128647793) (:text |e) (:id |8ladIKnrPo)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128648305) (:text |d!) (:id |QkRDyD2wId)
+                                            :id |Jopu5IfxAh
+                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128932918)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128933972)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128935549) (:text |:show) (:id |SIF7NAl3KWleaf)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128977081) (:text |load-plugin) (:id |S4jujrJbxm)
+                                                :id |Wx6nV1pFJ-
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128941098) (:text |d!) (:id |iR9u_eg1en)
+                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128941702)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128941993) (:text |fn) (:id |9phq1ASBt1)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128942187)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128943128) (:text |text) (:id |71Q4dulXR)
+                                                    :id |bWTsMadLok
+                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416325682)
+                                                    :data $ {}
+                                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416317462)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128962053)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |d!) (:id |Ev6fpsuC6v)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |cursor) (:id |xH5py6GBJo)
+                                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128962053)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |assoc) (:id |O7lsp9VND7)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |state) (:id |4fnfu4LHie)
+                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416470331) (:text |:result) (:id |HdXxbJw_vh)
+                                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416346587) (:text |snapshot) (:id |BrliPIG8J3)
+                                                                :id |M3E6Mit3VR
+                                                            :id |fruyqxiVrv
+                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416318378) (:text |if) (:id |xCQMTYsGku)
+                                                          |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416319136)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416320345) (:text |vector?) (:id |OF_9zNqvlO)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416339679) (:text |snapshot) (:id |LOXp67TaX5)
+                                                            :id |aKH3qeM7o
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128962053)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |d!) (:id |Ev6fpsuC6v)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |cursor) (:id |xH5py6GBJo)
+                                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128962053)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |assoc) (:id |O7lsp9VND7)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |state) (:id |4fnfu4LHie)
+                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |:result) (:id |HdXxbJw_vh)
+                                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416353585) (:text |snapshot) (:id |ORzNbwpxYv)
+                                                                :id |M3E6Mit3VR
+                                                            :id |N5rOIY434B
+                                                        :id |41SeRPdEBB
+                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416327433) (:text |let) (:id |RDIsDV-RBn)
+                                                      |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416328596)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416328765)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416336442) (:text |snapshot) (:id |8qOvrR4T-)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416337033)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416337033) (:text |read-string) (:id |SIgMM8qEli)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416337033) (:text |text) (:id |rbNG4FisFE)
+                                                                :id |6Ls_0PPmW3
+                                                            :id |blxgrum1c7
+                                                        :id |EWIWzc9JXs
+                                                      |P $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416365689)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416365689) (:text |println) (:id |3ZN18JJ_-r)
+                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416365689) (:text "|\"text") (:id |V7WeGCxigS)
+                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416369419) (:text |snapshot) (:id |N5zApeyFRC)
+                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416370721) (:text |;) (:id |W9M3ZwF1S1)
+                                                        :id |L6IbLgC1cn
+                                                    :id |nq0e7gX-wr
+                                                :id |s4OyQ22zo9
+                                            :id |SIF7NAl3KW
+                                        :id |wzmPXlilQ
+                                    :id |MIQsa5FHYz
+                                  |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128649511)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128652364) (:text |:style) (:id |AB-sga91uBleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128653995) (:text |ui/link) (:id |wOET7U7NJp)
+                                    :id |AB-sga91uB
+                                :id |BIJLSv_Td6
+                            :id |Wi-i_Ygfi6
                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191334213)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191334526) (:text |{}) (:id |D1uAB2qkc)
@@ -6493,106 +6816,6 @@
                                     :id |W93EUi_g-
                                 :id |M1RHWvLle
                             :id |MvsU7zgg
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191335707)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191337044) (:text |button) (:id |_q7WcX5AFleaf)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191337254)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191337530) (:text |{}) (:id |VqShIM50)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191338553)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191339268) (:text |:style) (:id |pZK5spdxa)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191340877) (:text |ui/button) (:id |V12mc-iJ4)
-                                    :id |VGO1CiNGo
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191344350)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191346967) (:text |:inner-text) (:id |OMsNKMkNVleaf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191354758) (:text "|\"Parse") (:id |02ZZp1UQh)
-                                    :id |OMsNKMkNV
-                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194152380)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194154070) (:text |:on-click) (:id |QXYMp8g5Uleaf)
-                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194154391)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194157539) (:text |fn) (:id |lWB3eSwoC)
-                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194157982)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194159068) (:text |e) (:id |KVJEby-B6)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194159570) (:text |d!) (:id |tBEiy8ZIX)
-                                            :id |qxsZyYcI5
-                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194160754)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194164273) (:text |let) (:id |Rf2Hsjb98leaf)
-                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194166857)
-                                                :data $ {}
-                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194167010)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194170086) (:text |result) (:id |JxUCXhFT)
-                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194177431)
-                                                        :data $ {}
-                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194295044)
-                                                            :data $ {}
-                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194170319)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194172974) (:text |:code) (:id |n0FJZRXW6)
-                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194173749) (:text |state) (:id |SWSLHDlMb)
-                                                                :id |xstp33DXV
-                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194298297) (:text |string/split) (:id |qBMaO4_w)
-                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194603171) (:text "|\"") (:id |AHE5N6pjK)
-                                                            :id |J14nY_KJ
-                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194179524) (:text |parse-lilac) (:id |Hi9fQ83yW)
-                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584207764294)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584207768084) (:text |s-expr-parser+) (:id |99JE86koleaf)
-                                                            :id |99JE86ko
-                                                        :id |CJKZsEmV
-                                                    :id |fu46X8I3D
-                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194167010)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588589406009) (:text |r1) (:id |JxUCXhFT)
-                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194177431)
-                                                        :data $ {}
-                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194295044)
-                                                            :data $ {}
-                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194170319)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194172974) (:text |:code) (:id |n0FJZRXW6)
-                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194173749) (:text |state) (:id |SWSLHDlMb)
-                                                                :id |xstp33DXV
-                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194298297) (:text |string/split) (:id |qBMaO4_w)
-                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194603171) (:text "|\"") (:id |AHE5N6pjK)
-                                                            :id |J14nY_KJ
-                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194179524) (:text |parse-lilac) (:id |Hi9fQ83yW)
-                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589106916159)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589106918656) (:text |value-parser+) (:id |ZOXzJKNSSj)
-                                                            :id |Z2YNTZvXx
-                                                        :id |CJKZsEmV
-                                                    :id |qY4W0BuYEi
-                                                :id |pBVZ8MzxK
-                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194271225)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1586663371849) (:text |d!) (:id |TniL48h_leaf)
-                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194274444)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194276259) (:text |assoc) (:id |LID-zo4vF)
-                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194276924) (:text |state) (:id |AHo2S2KuF)
-                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194280222) (:text |:result) (:id |iSsZCmDQa)
-                                                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610128840) (:text |r1) (:id |luXXvVz7i)
-                                                    :id |qKsHNyB_P
-                                                  |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1586663374206) (:text |cursor) (:id |jMu2x5204)
-                                                :id |TniL48h_
-                                            :id |Rf2Hsjb98
-                                        :id |EeOgrU6zg
-                                    :id |QXYMp8g5U
-                                :id |5hvLMNXs6
-                            :id |_q7WcX5AF
-                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584248218555)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584248219256) (:text |=<) (:id |hCrAjAXFAleaf)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584248219968) (:text |nil) (:id |3qvwqhdjd)
-                              |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584248756568) (:text |16) (:id |dELXDEV-)
-                            :id |hCrAjAXFA
                           |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584248222191)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584248231240) (:text |span) (:id |Or5OcEPAleaf)
@@ -6691,13 +6914,13 @@
                                     :id |1ncjwOYX
                                 :id |OK1sN-tnu
                             :id |Or5OcEPA
-                          |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128628888)
+                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584248218555)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128629507) (:text |=<) (:id |G0w1ilyn1qleaf)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128631817) (:text |16) (:id |EgIzfnsGt2)
-                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128632460) (:text |nil) (:id |zFgXXU3lXA)
-                            :id |G0w1ilyn1q
-                          |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128633044)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584248219256) (:text |=<) (:id |hCrAjAXFAleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584248219968) (:text |nil) (:id |3qvwqhdjd)
+                              |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584248756568) (:text |16) (:id |dELXDEV-)
+                            :id |hCrAjAXFA
+                          |yj $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128633044)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128635373) (:text |a) (:id |Wi-i_Ygfi6leaf)
                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128635577)
@@ -6706,7 +6929,7 @@
                                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128636100)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128641526) (:text |:inner-text) (:id |2WYP_OE-t9)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128643953) (:text "|\"Load EDN") (:id |2pTiqgoJkX)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415512790) (:text "|\"Replacer") (:id |2pTiqgoJkX)
                                     :id |YZWb_9sZ2
                                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128644691)
                                     :data $ {}
@@ -6719,49 +6942,85 @@
                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128647793) (:text |e) (:id |8ladIKnrPo)
                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128648305) (:text |d!) (:id |QkRDyD2wId)
                                             :id |Jopu5IfxAh
-                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128932918)
+                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415572218)
                                             :data $ {}
-                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128933972)
+                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416240153)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128935549) (:text |:show) (:id |SIF7NAl3KWleaf)
-                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128977081) (:text |load-plugin) (:id |S4jujrJbxm)
-                                                :id |Wx6nV1pFJ-
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128941098) (:text |d!) (:id |iR9u_eg1en)
-                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128941702)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128941993) (:text |fn) (:id |9phq1ASBt1)
-                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128942187)
+                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416240326)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128943128) (:text |text) (:id |71Q4dulXR)
-                                                    :id |bWTsMadLok
-                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128962053)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |d!) (:id |Ev6fpsuC6v)
-                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |cursor) (:id |xH5py6GBJo)
-                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128962053)
+                                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415534999)
                                                         :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |assoc) (:id |O7lsp9VND7)
-                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |state) (:id |4fnfu4LHie)
-                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128962053) (:text |:result) (:id |HdXxbJw_vh)
-                                                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128966422)
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415544200) (:text |replace-lilac) (:id |e-KqgyJFDl)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415534999)
                                                             :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128967669) (:text |read-string) (:id |MLnA5jWMpi)
-                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128970510) (:text |text) (:id |L1LB4I6gi)
-                                                            :id |zbEYPDeXp
-                                                        :id |M3E6Mit3VR
-                                                    :id |fruyqxiVrv
-                                                  |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589129073435)
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415534999) (:text |string/split) (:id |T8Uze_DKK4)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415534999)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415534999) (:text |:code) (:id |WqCuDDC1uz)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415534999) (:text |state) (:id |YhWuDzkboP)
+                                                                :id |l1UIznt3zQ
+                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415534999) (:text "|\"") (:id |vqh1JTEbqH)
+                                                            :id |0IC3eHY3Su
+                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415534999)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416045113) (:text |s-expr-parser+) (:id |e-slKIjeFA)
+                                                            :id |0KeGPpgY0Y
+                                                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415545596)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415546901) (:text |fn) (:id |nU28aAzxwAleaf)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415547130)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415551054) (:text |result) (:id |NK5XuU9dHZ)
+                                                                :id |_sne_mqHt
+                                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415556198)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415554253) (:text |println) (:id |MY1g7dqXxe)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415560463) (:text "|\"replacing") (:id |mFvtuCV0m0)
+                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415561559) (:text |result) (:id |xa2gRJpwsB)
+                                                                :id |Z1qwgMQ05u
+                                                              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415808041)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415820790) (:text "|\"<<<") (:id |1f0jYaK7o)
+                                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415808831) (:text |str) (:id |pYXknVJ34)
+                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415810083)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415810879) (:text |pr-str) (:id |OqdhjJ4XpC)
+                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415811829) (:text |result) (:id |FvYntARKB5)
+                                                                    :id |QSOiLnEq2
+                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415817904) (:text "|\">>>") (:id |9aaFmGVapL)
+                                                                :id |gxO-S6qOJ
+                                                            :id |nU28aAzxwA
+                                                        :id |NtmIGfq30n
+                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416241339) (:text |result) (:id |g6nmEmywU0)
+                                                    :id |1gkvwAMWwK
+                                                :id |DBDMyYsok
+                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416239529) (:text |let) (:id |WevJrvEirz)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416244298)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416244841) (:text |d!) (:id |oB5UQl_vnleaf)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416247181) (:text |cursor) (:id |B-IffuUwS)
+                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416247508)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589129074392) (:text |println) (:id |PunIbakvTleaf)
-                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589129075988) (:text "|\"text") (:id |U8Nz7fK_3p)
-                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589129088534)
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416248297) (:text |assoc) (:id |GE2_uueyv_)
+                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416249791) (:text |state) (:id |T5ovSAoul)
+                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416479360) (:text |:result) (:id |JRBMaFhujj)
+                                                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416258796)
                                                         :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589129076753) (:text |text) (:id |Z7cYm9LHVP)
-                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589129089109) (:text |read-string) (:id |4y46_rIgJP)
-                                                        :id |LpcP_55flW
-                                                    :id |PunIbakvT
-                                                :id |s4OyQ22zo9
-                                            :id |SIF7NAl3KW
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416256005) (:text |result) (:id |VHrV0KADw)
+                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416261396) (:text |:attempts) (:id |bH9lbtxjU)
+                                                        :id |haeaUg5pW
+                                                    :id |vD7PsnEMuo
+                                                :id |oB5UQl_vn
+                                              |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416620877)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416621734) (:text |println) (:id |vekqKqq3eKleaf)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416623504)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416625428) (:text |:result) (:id |U-acUXq8wB)
+                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416626363) (:text |result) (:id |p1_QpcDVvO)
+                                                    :id |TAMVsrTBw
+                                                :id |vekqKqq3eK
+                                            :id |ii6xkAaCE
                                         :id |wzmPXlilQ
                                     :id |MIQsa5FHYz
                                   |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128649511)
@@ -6770,7 +7029,113 @@
                                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128653995) (:text |ui/link) (:id |wOET7U7NJp)
                                     :id |AB-sga91uB
                                 :id |BIJLSv_Td6
-                            :id |Wi-i_Ygfi6
+                            :id |Y6o-v53Xq
+                          |yb $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415502975)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415503911) (:text |=<) (:id |_HTfHK9WTRleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415504624) (:text |16) (:id |pnad3Nc8I)
+                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415505188) (:text |nil) (:id |whnqJXduBq)
+                            :id |_HTfHK9WTR
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191335707)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191337044) (:text |button) (:id |_q7WcX5AFleaf)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191337254)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191337530) (:text |{}) (:id |VqShIM50)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191338553)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191339268) (:text |:style) (:id |pZK5spdxa)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191340877) (:text |ui/button) (:id |V12mc-iJ4)
+                                    :id |VGO1CiNGo
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584191344350)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191346967) (:text |:inner-text) (:id |OMsNKMkNVleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584191354758) (:text "|\"Parse") (:id |02ZZp1UQh)
+                                    :id |OMsNKMkNV
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194152380)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194154070) (:text |:on-click) (:id |QXYMp8g5Uleaf)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194154391)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194157539) (:text |fn) (:id |lWB3eSwoC)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194157982)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194159068) (:text |e) (:id |KVJEby-B6)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194159570) (:text |d!) (:id |tBEiy8ZIX)
+                                            :id |qxsZyYcI5
+                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194160754)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194164273) (:text |let) (:id |Rf2Hsjb98leaf)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194166857)
+                                                :data $ {}
+                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194167010)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194170086) (:text |result) (:id |JxUCXhFT)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194177431)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194295044)
+                                                            :data $ {}
+                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194170319)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194172974) (:text |:code) (:id |n0FJZRXW6)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194173749) (:text |state) (:id |SWSLHDlMb)
+                                                                :id |xstp33DXV
+                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194298297) (:text |string/split) (:id |qBMaO4_w)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194603171) (:text "|\"") (:id |AHE5N6pjK)
+                                                            :id |J14nY_KJ
+                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194179524) (:text |parse-lilac) (:id |Hi9fQ83yW)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584207764294)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584207768084) (:text |s-expr-parser+) (:id |99JE86koleaf)
+                                                            :id |99JE86ko
+                                                        :id |CJKZsEmV
+                                                    :id |fu46X8I3D
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194167010)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588589406009) (:text |r1) (:id |JxUCXhFT)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194177431)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194295044)
+                                                            :data $ {}
+                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194170319)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194172974) (:text |:code) (:id |n0FJZRXW6)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194173749) (:text |state) (:id |SWSLHDlMb)
+                                                                :id |xstp33DXV
+                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194298297) (:text |string/split) (:id |qBMaO4_w)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194603171) (:text "|\"") (:id |AHE5N6pjK)
+                                                            :id |J14nY_KJ
+                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194179524) (:text |parse-lilac) (:id |Hi9fQ83yW)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589106916159)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589106918656) (:text |value-parser+) (:id |ZOXzJKNSSj)
+                                                            :id |Z2YNTZvXx
+                                                        :id |CJKZsEmV
+                                                    :id |qY4W0BuYEi
+                                                :id |pBVZ8MzxK
+                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194271225)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1586663371849) (:text |d!) (:id |TniL48h_leaf)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194274444)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194276259) (:text |assoc) (:id |LID-zo4vF)
+                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194276924) (:text |state) (:id |AHo2S2KuF)
+                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194280222) (:text |:result) (:id |iSsZCmDQa)
+                                                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588610128840) (:text |r1) (:id |luXXvVz7i)
+                                                    :id |qKsHNyB_P
+                                                  |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1586663374206) (:text |cursor) (:id |jMu2x5204)
+                                                :id |TniL48h_
+                                            :id |Rf2Hsjb98
+                                        :id |EeOgrU6zg
+                                    :id |QXYMp8g5U
+                                :id |5hvLMNXs6
+                            :id |_q7WcX5AF
+                          |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128628888)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128629507) (:text |=<) (:id |G0w1ilyn1qleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128631817) (:text |16) (:id |EgIzfnsGt2)
+                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1589128632460) (:text |nil) (:id |zFgXXU3lXA)
+                            :id |G0w1ilyn1q
                         :id |V5HKKD-77
                       |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1589128923709)
                         :data $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -3743,7 +3743,20 @@
                               |j $ {} (:type :expr) (:time 1499755354983) (:id |H1l8go_FqTHZ)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:author |root) (:time 1499755354983) (:text |[]) (:id |SJ-Lgj_t5aS-)
-                                  |v $ {} (:type :leaf) (:author |root) (:time 1499755354983) (:text "|\"/client.js") (:id |HJNUxo_tcpSb) (:at 1544873988585) (:by |rJG4IHzWf)
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593411846897)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593411848105)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:author |root) (:time 1499755354983) (:text "|\"/client.js") (:id |HJNUxo_tcpSb) (:at 1544873988585) (:by |rJG4IHzWf)
+                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411851982) (:text |:src) (:id |DgRgKuWzlM)
+                                        :id |FA2pnzCPn
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411847575) (:text |{}) (:id |2ldikYngK)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593411853029)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411854222) (:text |:defer?) (:id |yNR_lXel1lleaf)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411855623) (:text |true) (:id |dgBOPBKZg5)
+                                        :id |yNR_lXel1l
+                                    :id |iJFyRbhu-N
                           |v $ {} (:type :expr) (:author |root) (:time 1510073430416) (:id |BklIiNIjqG)
                             :data $ {}
                               |T $ {} (:type :leaf) (:author |root) (:time 1510073435442) (:text |:inline-styles) (:id |rkg08EDyJzleaf)
@@ -3883,13 +3896,33 @@
                                   |v $ {} (:type :expr) (:author |root) (:time 1511096296215) (:id |Bkeel-1gM)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:author |root) (:time 1511096297101) (:text |map) (:id |Bkeel-1gMleaf)
-                                      |b $ {} (:type :expr) (:author |root) (:time 1511096299213) (:id |rkW7xl-1gM)
+                                      |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593411863674)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:author |root) (:time 1511096301200) (:text "|#()") (:id |r1xXxebylz)
-                                          |j $ {} (:type :leaf) (:author |root) (:time 1511096306997) (:text |->) (:id |S1Lexb1gz)
-                                          |r $ {} (:type :leaf) (:author |root) (:time 1511096308142) (:text |%) (:id |Hk2gxb1xf)
-                                          |v $ {} (:type :leaf) (:author |root) (:time 1511096313911) (:text |:output-name) (:id |HkRglb1gf)
-                                          |x $ {} (:type :leaf) (:author |root) (:time 1511096316067) (:text |prefix-cdn) (:id |S1XG-lWkeG)
+                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593411867105)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593411868290)
+                                                :data $ {}
+                                                  |T $ {} (:type :expr) (:author |root) (:time 1511096299213) (:id |rkW7xl-1gM)
+                                                    :data $ {}
+                                                      |j $ {} (:type :leaf) (:author |root) (:time 1511096306997) (:text |->) (:id |S1Lexb1gz)
+                                                      |r $ {} (:type :leaf) (:author |root) (:time 1511096308142) (:text |x) (:id |Hk2gxb1xf) (:at 1593411859891) (:by |rJG4IHzWf)
+                                                      |v $ {} (:type :leaf) (:author |root) (:time 1511096313911) (:text |:output-name) (:id |HkRglb1gf)
+                                                      |x $ {} (:type :leaf) (:author |root) (:time 1511096316067) (:text |prefix-cdn) (:id |S1XG-lWkeG)
+                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411869236) (:text |:src) (:id |IK5O3AjUEJ)
+                                                :id |46q_b3gW_O
+                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411867690) (:text |{}) (:id |OSBhKR5Uyy)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593411869671)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411871532) (:text |:defer?) (:id |hOzn2blrl_leaf)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411872142) (:text |true) (:id |UBsxSHtIsa)
+                                                :id |hOzn2blrl_
+                                            :id |WLrL9-lZF
+                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411864300) (:text |fn) (:id |_sHYSdfbND)
+                                          |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593411864596)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593411865830) (:text |x) (:id |EFDxxjIp2h)
+                                            :id |cnVX_qMrJ9
+                                        :id |-lc7j0rTKZ
                                       |j $ {} (:type :leaf) (:author |root) (:time 1511096298522) (:text |assets) (:id |B1fbxeZyeM)
                               |v $ {} (:type :expr) (:author |root) (:time 1500457145881) (:id |S16clidYcTSZ)
                                 :data $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1681,6 +1681,189 @@
                     :id |ZCPvWL5Um
                 :id |onzpn5Eqx2
             :id |FUq7aXDTW
+          |find-lilac $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428651920)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428661386) (:text |defn$) (:id |j_Z1nqU6Dm)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428651920) (:text |find-lilac) (:id |RslgRszd_s)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |content) (:id |rR3d3IuZ3Z)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |rule) (:id |aO983ryZuc)
+                    :id |slYGnc_MdF
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428669922) (:text |find-lilac) (:id |V5Qw5tq7BM)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593429396902)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429396463) (:text |[]) (:id |ClqcJYBZeK)
+                        :id |oAq0lXD0NJ
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |[]) (:id |H8Np0avQbt)
+                        :id |7KRGd8syGu
+                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |content) (:id |gD0NMsXQvY)
+                      |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |rule) (:id |pcNpW78DWF)
+                    :id |nwQZtQyJ5A
+                :id |3VTjgQmKs6
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |acc) (:id |eOSi8sPMIFo)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempts) (:id |vp-ha1K-TRm)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |content) (:id |C8MMxmJMIvK)
+                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |rule) (:id |uH0hkkZrjRu)
+                    :id |04IDf7e-v-j
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |assert) (:id |b7AC15VhSh8)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |sequential?) (:id |6b9fTnDB9uW)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |content) (:id |BMnbvSzqIX5)
+                        :id |FUPQOWyxOkW
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text "|\"expects content in sequence") (:id |-QshIxZkVfm)
+                    :id |cuaKgDeL_Tn
+                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |if) (:id |eQ-j86ZvxVH)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |empty?) (:id |m-IRKj066He)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |content) (:id |Ao1OxEm1dHL)
+                        :id |tOvNckCjzkr
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |{}) (:id |Fc-TN7Yi3_o)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |:result) (:id |16WQdWvN088)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |acc) (:id |_y-kL-GyAmE)
+                            :id |01jvafxS8_Z
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |:attempts) (:id |OsPwgtzt5md)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempts) (:id |qhNy8u3oahB)
+                            :id |fFk0LCn-Ux_
+                        :id |4PJ9_2-w5Af
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |let) (:id |yaxKWNfiSOD)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempt) (:id |HINcoj6tHOX)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |parse-lilac) (:id |V68lWenhktD)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |content) (:id |Wr3jOBxW8mA)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |rule) (:id |NQdkRkhnF3X)
+                                    :id |ysagLACVDlT
+                                :id |MCFeBjvMT58
+                            :id |pohRbj1Ud2J
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |if) (:id |9yQWsJVPTmA)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |:ok?) (:id |jEMNqzB5lKi)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempt) (:id |U35TbpgVhyo)
+                                :id |cMMeh358tPh
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |recur) (:id |LUFZC56H-BX)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429402125) (:text |conj) (:id |riW1eN9dEO7)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428834293) (:text |{}) (:id |swTnojlitK_)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428835246)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428915740)
+                                                :data $ {}
+                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428878754)
+                                                    :data $ {}
+                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428879630) (:text |take) (:id |ucCRredJus)
+                                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428883155) (:text |content) (:id |ZHZxr4p7Ne)
+                                                      |H $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593429307710)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429307710) (:text |-) (:id |xMFsWTiMfw)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593429307710)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429307710) (:text |count) (:id |eOJuU8VeNw)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429307710) (:text |content) (:id |vLFyyCA2e4)
+                                                            :id |TsUFcxH_gw
+                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593429307710)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429307710) (:text |count) (:id |t4_O-2cI1p)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593429307710)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429307710) (:text |:rest) (:id |iiNSkheQOA)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429307710) (:text |attempt) (:id |XLOxNdxEQy)
+                                                                :id |MPdKLH0KJD
+                                                            :id |4oRt4_l_zo
+                                                        :id |tTVK5BxbBH
+                                                    :id |SfJmfDjPP0
+                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428919608) (:text |->>) (:id |F2o78b6p-C)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428920094)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428921580) (:text |string/join) (:id |gCeHXnu9tleaf)
+                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428922304) (:text "|\"") (:id |P027u1ZQp)
+                                                    :id |gCeHXnu9t
+                                                :id |v-q2tzgRx
+                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428876155) (:text |:content) (:id |T3Ncc0nY00)
+                                            :id |F35XL166j
+                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428927315)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428939968) (:text |:value) (:id |OwtS0jdm-leaf)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428940599)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428941304) (:text |:value) (:id |m1kJXE26f)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428943299) (:text |attempt) (:id |Q0sA1naPP-)
+                                                :id |ctZQvhocAq
+                                            :id |OwtS0jdm-
+                                        :id |hcAq3ES1P1N
+                                      |f $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429402829) (:text |acc) (:id |qvLxVn1pb3)
+                                    :id |7Q_jByPDte9
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |conj) (:id |6viOrrVwefY)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempts) (:id |XnY_C23iKYR)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempt) (:id |HtNddW4AY9d)
+                                    :id |y-JJb-XiByy
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |:rest) (:id |r6GKYOEVXPK)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempt) (:id |aiVQiQ2-Nlb)
+                                    :id |RVdcz89hRt-
+                                  |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |rule) (:id |ywHpPUVMi2o)
+                                :id |1W0KwpaOIgc
+                              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |recur) (:id |nWOtf1Sz5Q-)
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |conj) (:id |MY7dovxH4JI)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempts) (:id |94k53eOaO6w)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |attempt) (:id |lOWBLlwBOht)
+                                    :id |Mi-Knqn76_U
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593428658430)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |rest) (:id |7-KZBo1piT9)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |content) (:id |2zxpUTZQV-W)
+                                    :id |3FOZowJu-LU
+                                  |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593428658430) (:text |rule) (:id |0wnHMlmaNQg)
+                                  |f $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429436726) (:text |acc) (:id |9qcRcUER4)
+                                :id |z1oCjdAziXF
+                            :id |d7FtNw2oN5L
+                        :id |F68SJGyoDbA
+                    :id |0LMmMTvGo3x
+                :id |biNAZiwPHDL
+            :id |I6gOJLQQmJ
           |combine+ $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584121099445)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588676645471) (:text |defn$) (:id |BIoTTIfLCD)
@@ -6020,6 +6203,7 @@
                         |n $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415624878) (:text |replace-lilac) (:id |o8VvouzKhG)
                         |yr $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584205007005) (:text |one-of+) (:id |uv__a9YVI)
                         |yT $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194253660) (:text |many+) (:id |zJQSAq2PK)
+                        |p $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429121844) (:text |find-lilac) (:id |suQTwidZm7)
                         |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584192945046) (:text |parse-lilac) (:id |PNms_EhbM)
                         |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194227038) (:text |combine+) (:id |KdaCiimcc)
                         |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194223312) (:text |is+) (:id |zvvfyjq1)
@@ -6986,6 +7170,28 @@
                                                         :id |NtmIGfq30n
                                                       |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416241339) (:text |result) (:id |g6nmEmywU0)
                                                     :id |1gkvwAMWwK
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416240326)
+                                                    :data $ {}
+                                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415534999)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429115777) (:text |find-lilac) (:id |e-KqgyJFDl)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415534999)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415534999) (:text |string/split) (:id |T8Uze_DKK4)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415534999)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415534999) (:text |:code) (:id |WqCuDDC1uz)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415534999) (:text |state) (:id |YhWuDzkboP)
+                                                                :id |l1UIznt3zQ
+                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593415534999) (:text "|\"") (:id |vqh1JTEbqH)
+                                                            :id |0IC3eHY3Su
+                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593415534999)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416045113) (:text |s-expr-parser+) (:id |e-slKIjeFA)
+                                                            :id |0KeGPpgY0Y
+                                                        :id |NtmIGfq30n
+                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429111068) (:text |find-result) (:id |g6nmEmywU0)
+                                                    :id |PuUXW24Ux
                                                 :id |DBDMyYsok
                                               |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416239529) (:text |let) (:id |WevJrvEirz)
                                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593416244298)
@@ -7013,6 +7219,20 @@
                                                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593416626363) (:text |result) (:id |p1_QpcDVvO)
                                                     :id |TAMVsrTBw
                                                 :id |vekqKqq3eK
+                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593429148959)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429149811) (:text |println) (:id |L0GZy7dowGleaf)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429157499) (:text "|\"Find results:") (:id |ZHwmNDXuG5)
+                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593429481536)
+                                                    :data $ {}
+                                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593429158603)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429153181) (:text |find-result) (:id |70s3Ly9jMN)
+                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429362730) (:text |:result) (:id |sqf-LGBeK-)
+                                                        :id |yCLZ-KKe9
+                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593429482712) (:text |pr-str) (:id |XJwlfSdyZW)
+                                                    :id |hcwUHhoxIR
+                                                :id |L0GZy7dowG
                                             :id |ii6xkAaCE
                                         :id |wzmPXlilQ
                                     :id |MIQsa5FHYz

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -85,13 +85,6 @@
                     |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584185352414) (:text |:as) (:id |0NBEa5wh)
                     |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584185353115) (:text |string) (:id |BoEcGb1zo)
                   :id |1pm5C9niW
-                |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584194957865)
-                  :data $ {}
-                    |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194959304) (:text |[]) (:id |T5z96MAZyleaf)
-                    |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194959784) (:text |cirru-edn.core) (:id |LV5ElYK1c)
-                    |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194968117) (:text |:as) (:id |_fRNYmiMi)
-                    |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584194970676) (:text |cirru-edn) (:id |tdzxqJdHQ)
-                  :id |T5z96MAZy
                 |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1588583714225)
                   :data $ {}
                     |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1588583714843) (:text |[]) (:id |8nhgzFWiZleaf)

--- a/deps.edn
+++ b/deps.edn
@@ -4,9 +4,9 @@
   :aliases {
     :release {
       :extra-deps {
-        appliedscience/deps-library {:mvn/version "0.3.4"}
+        applied-science/deps-library {:mvn/version "0.4.0"}
       }
-      :main-opts ["-m" "deps-library.release"]
+      :main-opts ["-m" "applied-science.deps-library"]
     }
   }
 }

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 
 {
-  :paths ["src"]
+  :paths ["src" "macros"]
   :aliases {
     :release {
       :extra-deps {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "@mvc-works/codearea": "^0.0.2",
-    "shadow-cljs": "^2.9.8",
+    "shadow-cljs": "^2.10.13",
     "source-map-support": "^0.5.19",
     "ws": "^7.3.0"
   },

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.0.3-a1"
+{:version "0.0.3-a2"
  :group-id "mvc-works"
  :artifact-id "lilac-parser"
  :skip-tag true

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.0.3-a3"
+{:version "0.0.3-a4"
  :group-id "mvc-works"
  :artifact-id "lilac-parser"
  :skip-tag true

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.0.2-a3"
+{:version "0.0.3-a1"
  :group-id "mvc-works"
  :artifact-id "lilac-parser"
  :skip-tag true

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.0.3-a2"
+{:version "0.0.3-a3"
  :group-id "mvc-works"
  :artifact-id "lilac-parser"
  :skip-tag true

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -3,15 +3,15 @@
   :cache-blockers #{cumulo-util.build}
   :dependencies [
     [mvc-works/hsl "0.1.2"]
-    [mvc-works/shell-page "0.1.10"]
-    [respo "0.12.1"]
-    [respo/ui "0.3.14"]
-    [respo/alerts "0.5.1"]
+    [mvc-works/shell-page "0.1.14"]
+    [respo "0.12.3"]
+    [respo/ui "0.3.15"]
+    [respo/alerts "0.5.5"]
     [respo/value "0.3.0"]
     [respo/markdown "0.2.5"]
     [respo/feather "0.1.1"]
-    [respo/reel "0.4.0"]
-    [cumulo/util "0.1.10"]
+    [respo/reel "0.4.2"]
+    [cumulo/util "0.1.12"]
     [cirru/edn "0.0.9"]
     [medley "1.3.0"]
     [cirru/favored-edn "0.1.3"]
@@ -40,11 +40,7 @@
       :target :node-script, :output-to "target/page.js", :main lilac-parser.page/main!
       :devtools {:after-load lilac-parser.page/main!}
     }
-    :test {
-      :target :node-test, :output-to "target/test.js", :ns-regexp "test$", :autorun true
-    }
-    :test-only {
-      :target :node-test, :output-to "target/test.js", :ns-regexp "test$"
-    }
+    :test {:target :node-test, :output-to "target/test.js", :ns-regexp "test$", :autorun true}
+    :test-only {:target :node-test, :output-to "target/test.js", :ns-regexp "test$"}
   }
 }

--- a/src/lilac_parser/comp/container.cljs
+++ b/src/lilac_parser/comp/container.cljs
@@ -13,6 +13,7 @@
              :refer
              [parse-lilac
               replace-lilac
+              find-lilac
               defparser
               is+
               combine+
@@ -184,9 +185,11 @@
                        (s-expr-parser+)
                        (fn [result]
                          (println "replacing" result)
-                         (str "<<<" (pr-str result) ">>>")))]
+                         (str "<<<" (pr-str result) ">>>")))
+               find-result (find-lilac (string/split (:code state) "") (s-expr-parser+))]
            (println (:result result))
-           (d! cursor (assoc state :result (:attempts result)))))}))
+           (d! cursor (assoc state :result (:attempts result)))
+           (println "Find results:" (pr-str (:result find-result)))))}))
     (div
      {:style (merge ui/expand ui/row)}
      (textarea

--- a/src/lilac_parser/core.cljs
+++ b/src/lilac_parser/core.cljs
@@ -294,6 +294,27 @@
      (println "Unexpected parameter passed to other-than+ :" items))
    {:parser-node :other-than, :items items, :transform transform}))
 
+(defn replace-lilac
+  ([content rule replacer] (replace-lilac "" [] content rule replacer))
+  ([acc attempts content rule replacer]
+   (assert (sequential? content) "expects content in sequence")
+   (if (empty? content)
+     {:result acc, :attempts attempts}
+     (let [attempt (parse-lilac content rule)]
+       (if (:ok? attempt)
+         (recur
+          (str acc (replacer (:value attempt)))
+          (conj attempts attempt)
+          (:rest attempt)
+          rule
+          replacer)
+         (recur
+          (str acc (first content))
+          (conj attempts attempt)
+          (rest content)
+          rule
+          replacer))))))
+
 (defn resigter-custom-rule! [kind f]
   (assert (keyword? kind) "expects kind in keyword")
   (assert (fn? f) "expects parser rule in function")

--- a/src/lilac_parser/core.cljs
+++ b/src/lilac_parser/core.cljs
@@ -251,6 +251,25 @@
    :other-than parse-other-than,
    :label parse-label})
 
+(defn find-lilac
+  ([content rule] (find-lilac [] [] content rule))
+  ([acc attempts content rule]
+   (assert (sequential? content) "expects content in sequence")
+   (if (empty? content)
+     {:result acc, :attempts attempts}
+     (let [attempt (parse-lilac content rule)]
+       (if (:ok? attempt)
+         (recur
+          (conj
+           acc
+           {:content (->> (take (- (count content) (count (:rest attempt))) content)
+                          (string/join "")),
+            :value (:value attempt)})
+          (conj attempts attempt)
+          (:rest attempt)
+          rule)
+         (recur acc (conj attempts attempt) (rest content) rule))))))
+
 (defn indent+
   ([] (indent+ identity))
   ([transform] {:parser-node :indent, :transform transform}))

--- a/src/lilac_parser/core.cljs
+++ b/src/lilac_parser/core.cljs
@@ -2,7 +2,6 @@
 (ns lilac-parser.core
   (:require-macros [lilac-parser.core])
   (:require [clojure.string :as string]
-            [cirru-edn.core :as cirru-edn]
             [lilac-parser.config :refer [dev?]]
             [lilac-parser.util :refer [seq-strip-beginning]]))
 

--- a/src/lilac_parser/page.cljs
+++ b/src/lilac_parser/page.cljs
@@ -19,7 +19,7 @@
    (merge
     base-info
     {:styles [(<< "http://~(get-ip!):8100/main.css") "/entry/main.css"],
-     :scripts ["/client.js"],
+     :scripts [{:src "/client.js", :defer? true}],
      :inline-styles []})))
 
 (defn prod-page []
@@ -33,7 +33,7 @@
      (merge
       base-info
       {:styles [(:release-ui config/site)],
-       :scripts (map #(-> % :output-name prefix-cdn) assets),
+       :scripts (map (fn [x] {:src (-> x :output-name prefix-cdn), :defer? true}) assets),
        :ssr "respo-ssr",
        :inline-styles [(slurp "./entry/main.css")]}))))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,13 +4,13 @@
 
 "@mvc-works/codearea@^0.0.2":
   version "0.0.2"
-  resolved "https://registry.npm.taobao.org/@mvc-works/codearea/download/@mvc-works/codearea-0.0.2.tgz#9e9b8ea26111f870f36752dd790b15716b8201af"
-  integrity sha1-npuOomER+HDzZ1LdeQsVcWuCAa8=
+  resolved "https://registry.npmjs.org/@mvc-works/codearea/-/codearea-0.0.2.tgz#9e9b8ea26111f870f36752dd790b15716b8201af"
+  integrity sha512-HHkFO9qRfeGnwdxwMhVxxExiqvSgl8MiP5RXzNWWtR4Zg8Ue6UUzgaaG+ICQi9hemA2L2Dydp7K0meFFm1DHpw==
 
 asn1.js@^4.0.0:
   version "4.10.1"
-  resolved "https://registry.npm.taobao.org/asn1.js/download/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
-  integrity sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=
+  resolved "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
+  integrity sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -18,41 +18,41 @@ asn1.js@^4.0.0:
 
 assert@^1.1.1:
   version "1.5.0"
-  resolved "https://registry.npm.taobao.org/assert/download/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
-  integrity sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=
+  resolved "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
+  integrity sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==
   dependencies:
     object-assign "^4.1.1"
     util "0.10.3"
 
 async-limiter@~1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/async-limiter/download/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=
+  resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 base64-js@^1.0.2:
   version "1.3.1"
-  resolved "https://registry.npm.taobao.org/base64-js/download/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=
+  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"
-  resolved "https://registry.npm.taobao.org/bn.js/download/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
-  integrity sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=
+  resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
+  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 bn.js@^5.1.1:
   version "5.1.2"
-  resolved "https://registry.npm.taobao.org/bn.js/download/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
-  integrity sha1-yWhpAtPJoncp9DqxD515wgBNp7A=
+  resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
+  integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
 
 brorand@^1.0.1:
   version "1.1.0"
-  resolved "https://registry.npm.taobao.org/brorand/download/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  resolved "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-aes/download/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
-  integrity sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=
+  resolved "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
   dependencies:
     buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
@@ -63,8 +63,8 @@ browserify-aes@^1.0.0, browserify-aes@^1.0.4:
 
 browserify-cipher@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/browserify-cipher/download/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
-  integrity sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=
+  resolved "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
+  integrity sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
   dependencies:
     browserify-aes "^1.0.4"
     browserify-des "^1.0.0"
@@ -72,8 +72,8 @@ browserify-cipher@^1.0.0:
 
 browserify-des@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/browserify-des/download/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
-  integrity sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=
+  resolved "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
+  integrity sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
   dependencies:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
@@ -82,7 +82,7 @@ browserify-des@^1.0.0:
 
 browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.npm.taobao.org/browserify-rsa/download/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
+  resolved "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
   integrity sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
   dependencies:
     bn.js "^4.1.0"
@@ -90,8 +90,8 @@ browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
 
 browserify-sign@^4.0.0:
   version "4.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-sign/download/browserify-sign-4.2.0.tgz#545d0b1b07e6b2c99211082bf1b12cce7a0b0e11"
-  integrity sha1-VF0LGwfmssmSEQgr8bEsznoLDhE=
+  resolved "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz#545d0b1b07e6b2c99211082bf1b12cce7a0b0e11"
+  integrity sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==
   dependencies:
     bn.js "^5.1.1"
     browserify-rsa "^4.0.1"
@@ -105,25 +105,25 @@ browserify-sign@^4.0.0:
 
 browserify-zlib@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-zlib/download/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
-  integrity sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=
+  resolved "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
+  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   dependencies:
     pako "~1.0.5"
 
 buffer-from@^1.0.0:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=
+  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer-xor@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.npm.taobao.org/buffer-xor/download/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+  resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^4.3.0:
   version "4.9.2"
-  resolved "https://registry.npm.taobao.org/buffer/download/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
-  integrity sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=
+  resolved "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -131,54 +131,54 @@ buffer@^4.3.0:
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npm.taobao.org/builtin-status-codes/download/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+  resolved "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
-  resolved "https://registry.npm.taobao.org/cipher-base/download/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
-  integrity sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=
+  resolved "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
 classnames@^2.2.5:
   version "2.2.6"
-  resolved "https://registry.npm.taobao.org/classnames/download/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4=
+  resolved "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 console-browserify@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/console-browserify/download/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
-  integrity sha1-ZwY871fOts9Jk6KrOlWECujEkzY=
+  resolved "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
+  integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
 constants-browserify@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/constants-browserify/download/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+  resolved "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
 core-js@^3.1.3:
   version "3.6.5"
-  resolved "https://registry.npm.taobao.org/core-js/download/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha1-c5XcJzrzf7LlDpvT2f6EEoUjHRo=
+  resolved "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@~1.0.0:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/core-util-is/download/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 create-ecdh@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.npm.taobao.org/create-ecdh/download/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
-  integrity sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=
+  resolved "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
+  integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/create-hash/download/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
-  integrity sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=
+  resolved "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
@@ -188,8 +188,8 @@ create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
 
 create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
   version "1.1.7"
-  resolved "https://registry.npm.taobao.org/create-hmac/download/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
-  integrity sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=
+  resolved "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
   dependencies:
     cipher-base "^1.0.3"
     create-hash "^1.1.0"
@@ -200,8 +200,8 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
-  resolved "https://registry.npm.taobao.org/crypto-browserify/download/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
-  integrity sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=
+  resolved "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
   dependencies:
     browserify-cipher "^1.0.0"
     browserify-sign "^4.0.0"
@@ -217,16 +217,16 @@ crypto-browserify@^3.11.0:
 
 des.js@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/des.js/download/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
-  integrity sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=
+  resolved "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
+  integrity sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
-  resolved "https://registry.npm.taobao.org/diffie-hellman/download/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
-  integrity sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=
+  resolved "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
+  integrity sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
   dependencies:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
@@ -234,13 +234,13 @@ diffie-hellman@^5.0.0:
 
 domain-browser@^1.1.1:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/domain-browser/download/domain-browser-1.2.0.tgz?cache=0&sync_timestamp=1590072213865&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomain-browser%2Fdownload%2Fdomain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
-  integrity sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=
+  resolved "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+  integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
 elliptic@^6.0.0, elliptic@^6.5.2:
-  version "6.5.2"
-  resolved "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-  integrity sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=
+  version "6.5.3"
+  resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -252,29 +252,29 @@ elliptic@^6.0.0, elliptic@^6.5.2:
 
 events@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.npm.taobao.org/events/download/events-3.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fevents%2Fdownload%2Fevents-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
-  integrity sha1-hCea8bNMt1qoi/X/KR9tC9mzGlk=
+  resolved "https://registry.npmjs.org/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
+  integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.npm.taobao.org/evp_bytestokey/download/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
-  integrity sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=
+  resolved "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
+  integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
 feather-icons@^4.28.0:
   version "4.28.0"
-  resolved "https://registry.npm.taobao.org/feather-icons/download/feather-icons-4.28.0.tgz#e1892a401fe12c4559291770ff6e68b0168e760f"
-  integrity sha1-4YkqQB/hLEVZKRdw/25osBaOdg8=
+  resolved "https://registry.npmjs.org/feather-icons/-/feather-icons-4.28.0.tgz#e1892a401fe12c4559291770ff6e68b0168e760f"
+  integrity sha512-gRdqKESXRBUZn6Nl0VBq2wPHKRJgZz7yblrrc2lYsS6odkNFDnA4bqvrlEVRUPjE1tFax+0TdbJKZ31ziJuzjg==
   dependencies:
     classnames "^2.2.5"
     core-js "^3.1.3"
 
 hash-base@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.npm.taobao.org/hash-base/download/hash-base-3.1.0.tgz?cache=0&sync_timestamp=1588318012719&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhash-base%2Fdownload%2Fhash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
-  integrity sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=
+  resolved "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
   dependencies:
     inherits "^2.0.4"
     readable-stream "^3.6.0"
@@ -282,15 +282,15 @@ hash-base@^3.0.0:
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
-  resolved "https://registry.npm.taobao.org/hash.js/download/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=
+  resolved "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/hmac-drbg/download/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  resolved "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
   dependencies:
     hash.js "^1.0.3"
@@ -299,43 +299,43 @@ hmac-drbg@^1.0.0:
 
 https-browserify@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/https-browserify/download/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+  resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
 ieee754@^1.1.4:
   version "1.1.13"
-  resolved "https://registry.npm.taobao.org/ieee754/download/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 inherits@2.0.1:
   version "2.0.1"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 inherits@2.0.3:
   version "2.0.3"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 md5.js@^1.3.4:
   version "1.3.5"
-  resolved "https://registry.npm.taobao.org/md5.js/download/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
-  integrity sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=
+  resolved "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
@@ -343,31 +343,31 @@ md5.js@^1.3.4:
 
 miller-rabin@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.npm.taobao.org/miller-rabin/download/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
-  integrity sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=
+  resolved "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
   dependencies:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/minimalistic-assert/download/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=
+  resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 nanoid@^2.1.0:
   version "2.1.11"
-  resolved "https://registry.npm.taobao.org/nanoid/download/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha1-7CS4p1jVkVYVMbQXagHjq08PAoA=
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
 node-libs-browser@^2.0.0:
   version "2.2.1"
-  resolved "https://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
-  integrity sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=
+  resolved "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
+  integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
   dependencies:
     assert "^1.1.1"
     browserify-zlib "^0.2.0"
@@ -395,23 +395,23 @@ node-libs-browser@^2.0.0:
 
 object-assign@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fobject-assign%2Fdownload%2Fobject-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 os-browserify@^0.3.0:
   version "0.3.0"
-  resolved "https://registry.npm.taobao.org/os-browserify/download/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
+  resolved "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
 pako@~1.0.5:
   version "1.0.11"
-  resolved "https://registry.npm.taobao.org/pako/download/pako-1.0.11.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpako%2Fdownload%2Fpako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=
+  resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
   version "5.1.5"
-  resolved "https://registry.npm.taobao.org/parse-asn1/download/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
-  integrity sha1-ADJxND2ljclMrOSU+u89IUfs6g4=
+  resolved "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
+  integrity sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
@@ -422,13 +422,13 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
 
 path-browserify@0.0.1:
   version "0.0.1"
-  resolved "https://registry.npm.taobao.org/path-browserify/download/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
-  integrity sha1-5sTd1+06onxoogzE5Q4aTug7vEo=
+  resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
+  integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
 
 pbkdf2@^3.0.3:
-  version "3.0.17"
-  resolved "https://registry.npm.taobao.org/pbkdf2/download/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
-  integrity sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
+  integrity sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -438,18 +438,18 @@ pbkdf2@^3.0.3:
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
-  resolved "https://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha1-eCDZsWEgzFXKmud5JoCufbptf+I=
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 process@^0.11.10:
   version "0.11.10"
-  resolved "https://registry.npm.taobao.org/process/download/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 public-encrypt@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.npm.taobao.org/public-encrypt/download/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
-  integrity sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=
+  resolved "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
+  integrity sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
   dependencies:
     bn.js "^4.1.0"
     browserify-rsa "^4.0.0"
@@ -460,43 +460,43 @@ public-encrypt@^4.0.0:
 
 punycode@1.3.2:
   version "1.3.2"
-  resolved "https://registry.npm.taobao.org/punycode/download/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@^1.2.4:
   version "1.4.1"
-  resolved "https://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 querystring-es3@^0.2.0:
   version "0.2.1"
-  resolved "https://registry.npm.taobao.org/querystring-es3/download/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+  resolved "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
 
 querystring@0.2.0:
   version "0.2.0"
-  resolved "https://registry.npm.taobao.org/querystring/download/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
-  resolved "https://registry.npm.taobao.org/randombytes/download/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=
+  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
 
 randomfill@^1.0.3:
   version "1.0.4"
-  resolved "https://registry.npm.taobao.org/randomfill/download/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
-  integrity sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=
+  resolved "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
+  integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
 readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.7"
-  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -508,8 +508,8 @@ readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
 
 readable-stream@^3.6.0:
   version "3.6.0"
-  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha1-M3u9o63AcGvT4CRCaihtS0sskZg=
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -517,49 +517,49 @@ readable-stream@^3.6.0:
 
 readline-sync@^1.4.7:
   version "1.4.10"
-  resolved "https://registry.npm.taobao.org/readline-sync/download/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
-  integrity sha1-Qd9/u0tjEtZzARWUFFcFv1bYhzs=
+  resolved "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npm.taobao.org/ripemd160/download/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
-  integrity sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=
+  resolved "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
-  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.2.1.tgz?cache=0&sync_timestamp=1589129611964&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsafe-buffer%2Fdownload%2Fsafe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
-  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz?cache=0&sync_timestamp=1589129611964&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsafe-buffer%2Fdownload%2Fsafe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha1-mR7GnSluAxN0fVm9/St0XDX4go0=
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 setimmediate@^1.0.4:
   version "1.0.5"
-  resolved "https://registry.npm.taobao.org/setimmediate/download/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  resolved "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
-  resolved "https://registry.npm.taobao.org/sha.js/download/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=
+  resolved "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
 shadow-cljs-jar@1.3.2:
   version "1.3.2"
-  resolved "https://registry.npm.taobao.org/shadow-cljs-jar/download/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
-  integrity sha1-lyc6/hdHtqIxGRfByI2eJDyBlXs=
+  resolved "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
+  integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
 
-shadow-cljs@^2.9.8:
-  version "2.9.8"
-  resolved "https://registry.npm.taobao.org/shadow-cljs/download/shadow-cljs-2.9.8.tgz#df4eada8449c195deeef7e3d8f39de6fc084f5f0"
-  integrity sha1-306tqEScGV3u7349jzneb8CE9fA=
+shadow-cljs@^2.10.13:
+  version "2.10.13"
+  resolved "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.10.13.tgz#8e9f74901b51cd22169fc476eae048dba5a40c93"
+  integrity sha512-I3TJeh/hwJFwKruALnKrWVPnqbdou+tXQ++SWwOfN0CiYHcj4MMhyfBJfMsKPiOsOouRCCYTQVqsiJHIitK2/Q==
   dependencies:
     node-libs-browser "^2.0.0"
     readline-sync "^1.4.7"
@@ -570,48 +570,48 @@ shadow-cljs@^2.9.8:
 
 shortid@^2.2.15:
   version "2.2.15"
-  resolved "https://registry.npm.taobao.org/shortid/download/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
-  integrity sha1-K5AuqpOmmxESA3PNQqHx/kQ3wSI=
+  resolved "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
+  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
   dependencies:
     nanoid "^2.1.0"
 
 source-map-support@^0.4.15:
   version "0.4.18"
-  resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  integrity sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
   dependencies:
     source-map "^0.5.6"
 
 source-map-support@^0.5.19:
   version "0.5.19"
-  resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map@^0.5.6:
   version "0.5.7"
-  resolved "https://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 source-map@^0.6.0:
   version "0.6.1"
-  resolved "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha1-dHIq8y6WFOnCh6jQu95IteLxomM=
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 stream-browserify@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npm.taobao.org/stream-browserify/download/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
-  integrity sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=
+  resolved "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
+  integrity sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
 stream-http@^2.7.2:
   version "2.8.3"
-  resolved "https://registry.npm.taobao.org/stream-http/download/stream-http-2.8.3.tgz?cache=0&sync_timestamp=1588701397289&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstream-http%2Fdownload%2Fstream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
-  integrity sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=
+  resolved "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -621,43 +621,43 @@ stream-http@^2.7.2:
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
-  resolved "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
 timers-browserify@^2.0.4:
   version "2.0.11"
-  resolved "https://registry.npm.taobao.org/timers-browserify/download/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
-  integrity sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=
+  resolved "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
+  integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
   dependencies:
     setimmediate "^1.0.4"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/to-arraybuffer/download/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+  resolved "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
 tty-browserify@0.0.0:
   version "0.0.0"
-  resolved "https://registry.npm.taobao.org/tty-browserify/download/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+  resolved "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
 ultron@~1.1.0:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/ultron/download/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-  integrity sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=
+  resolved "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
 url@^0.11.0:
   version "0.11.0"
-  resolved "https://registry.npm.taobao.org/url/download/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  resolved "https://registry.npmjs.org/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
   dependencies:
     punycode "1.3.2"
@@ -665,39 +665,39 @@ url@^0.11.0:
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/util-deprecate/download/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util@0.10.3:
   version "0.10.3"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.10.3.tgz?cache=0&sync_timestamp=1588238397004&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil%2Fdownload%2Futil-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  resolved "https://registry.npmjs.org/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
 util@^0.11.0:
   version "0.11.1"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.11.1.tgz?cache=0&sync_timestamp=1588238397004&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil%2Fdownload%2Futil-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
-  integrity sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=
+  resolved "https://registry.npmjs.org/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
-  resolved "https://registry.npm.taobao.org/vm-browserify/download/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
-  integrity sha1-eGQcSIuObKkadfUR56OzKobl3aA=
+  resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
+  integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
 which@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.npm.taobao.org/which/download/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=
+  resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 ws@^3.0.0:
   version "3.3.3"
-  resolved "https://registry.npm.taobao.org/ws/download/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  integrity sha1-8c+E/i1ekB686U767OeF8YeiKPI=
+  resolved "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
@@ -705,10 +705,10 @@ ws@^3.0.0:
 
 ws@^7.3.0:
   version "7.3.0"
-  resolved "https://registry.npm.taobao.org/ws/download/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
-  integrity sha1-Sy9/IZs9Nze8Gi+/FF2CW5TTj/0=
+  resolved "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
+  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
 
 xtend@^4.0.0:
   version "4.0.2"
-  resolved "https://registry.npm.taobao.org/xtend/download/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
-  integrity sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=
+  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
Added new function as a tool similar to regex string replacement...

```
(replace-lilac (string/split content "") rule (fn [x] (str "<<<" x ">>>>")))
```